### PR TITLE
Fix configuration paths and attachment filtering

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_src_on_path() -> None:
+    root = Path(__file__).resolve().parents[1]
+    src = root / "src"
+    src_str = str(src)
+    if src_str not in sys.path:
+        sys.path.insert(0, src_str)
+
+
+_ensure_src_on_path()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+from forward_monitor.config import MonitorConfig
+
+
+def _write_config(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def test_state_file_relative_to_config(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_path = config_dir / "config.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        state_file: state/monitor.json
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+
+    expected = config_dir / "state" / "monitor.json"
+    assert config.state_file == expected
+
+
+def test_default_state_file_uses_config_directory(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+
+    assert config.state_file == tmp_path / "monitor_state.json"

--- a/tests/test_monitor_filters.py
+++ b/tests/test_monitor_filters.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from forward_monitor.formatter import AttachmentInfo
+from forward_monitor.monitor import _attachment_category, _message_types, _should_forward
+from forward_monitor.config import MessageFilters
+
+
+def test_attachment_category_supports_file_alias() -> None:
+    attachment = AttachmentInfo(
+        url="https://example.com/document.pdf",
+        filename="document.pdf",
+        content_type="application/pdf",
+    )
+
+    assert _attachment_category(attachment) == "file"
+
+
+def test_should_forward_respects_file_alias_in_filters() -> None:
+    attachment = AttachmentInfo(
+        url="https://example.com/archive.zip",
+        filename="archive.zip",
+        content_type=None,
+    )
+
+    filters = MessageFilters(allowed_types=["file"])
+    message = {"author": {"id": "42"}}
+
+    assert _should_forward(message, "", [attachment], filters)
+
+
+def test_message_types_include_document_alias() -> None:
+    attachment = AttachmentInfo(
+        url="https://example.com/archive.zip",
+        filename="archive.zip",
+        content_type=None,
+    )
+
+    types = _message_types("", [attachment])
+
+    assert "file" in types
+    assert "document" in types


### PR DESCRIPTION
## Summary
- resolve monitor state file paths relative to the configuration file and centralize default values
- align attachment type detection with documented filter options and refactor attachment sending helpers
- add tests covering configuration path handling and attachment filtering logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd999263a4832b9937bd68a6be0ace