### PR TITLE
Handle missing Discord channels gracefully

### DIFF
--- a/src/forward_monitor/discord_client.py
+++ b/src/forward_monitor/discord_client.py
@@ -9,6 +9,15 @@ import aiohttp
 DISCORD_API_BASE = "https://discord.com/api/v10"
 
 
+class DiscordAPIError(RuntimeError):
+    """Error raised when the Discord API returns a non-success response."""
+
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"Discord API request failed with status {status}: {body}")
+        self.status = status
+        self.body = body
+
+
 class DiscordClient:
     """Simple HTTP client for the Discord REST API."""
 
@@ -53,9 +62,7 @@ class DiscordClient:
 
                 if response.status >= 400:
                     text = await response.text()
-                    raise RuntimeError(
-                        f"Discord API request failed with status {response.status}: {text}"
-                    )
+                    raise DiscordAPIError(response.status, text)
 
                 content_type = response.headers.get("Content-Type", "")
                 if "application/json" not in content_type:


### PR DESCRIPTION
## Summary
- add a dedicated `DiscordAPIError` to surface Discord response status codes
- log clear configuration guidance when a Discord channel cannot be found

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cda6719884832bb598fed1cf81b44b