### PR TITLE
Normalize pinned message IDs when tracking

### DIFF
--- a/src/forward_monitor/monitor.py
+++ b/src/forward_monitor/monitor.py
@@ -200,13 +200,21 @@ async def _sync_pins(
                 )
                 continue
             raise
-        known_pins = set(state.get_known_pins(channel_id))
-        current_pin_ids = {pin["id"] for pin in pins}
+        known_pins = {str(pin_id) for pin_id in state.get_known_pins(channel_id)}
+        message_items: List[tuple[str, dict]] = []
+        current_pin_ids: Set[str] = set()
+        for pin in pins:
+            message_id = pin.get("id")
+            if message_id is None:
+                continue
+            message_id_text = str(message_id)
+            message_items.append((message_id_text, pin))
+            current_pin_ids.add(message_id_text)
 
         new_pin_ids = current_pin_ids - known_pins
         if new_pin_ids:
-            for message in pins:
-                if message["id"] in new_pin_ids:
+            for message_id, message in message_items:
+                if message_id in new_pin_ids:
                     await _forward_message(
                         context=context,
                         channel_id=channel_id,

--- a/tests/test_monitor_pins.py
+++ b/tests/test_monitor_pins.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Any, Iterable, List
+
+import pytest
+
+from forward_monitor.config import (
+    ChannelMapping,
+    MessageCustomization,
+    MessageFilters,
+)
+from forward_monitor.monitor import ChannelContext, _sync_pins
+from forward_monitor.state import MonitorState
+
+
+class _StubDiscord:
+    def __init__(self, pins: Iterable[dict[str, Any]]):
+        self._pins: List[dict[str, Any]] = list(pins)
+
+    async def fetch_pins(self, channel_id: int) -> List[dict[str, Any]]:
+        return list(self._pins)
+
+
+class _StubTelegram:
+    def __init__(self) -> None:
+        self.messages: List[tuple[str, str]] = []
+
+    async def send_message(self, chat_id: str, text: str) -> None:
+        self.messages.append((chat_id, text))
+
+    async def send_photo(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("unexpected media upload")
+
+    async def send_video(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("unexpected media upload")
+
+    async def send_audio(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("unexpected media upload")
+
+    async def send_document(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("unexpected media upload")
+
+
+@pytest.mark.asyncio
+async def test_sync_pins_handles_non_string_ids(tmp_path: Path) -> None:
+    state = MonitorState(tmp_path / "state.json")
+    state.set_known_pins(42, ["101"])
+    state.save()
+
+    discord = _StubDiscord(
+        [
+            {
+                "id": 101,
+                "content": "old",
+                "author": {"username": "Alice", "id": "1"},
+                "attachments": [],
+            },
+            {
+                "id": 202,
+                "content": "New pinned",
+                "author": {"username": "Bob", "id": "2"},
+                "attachments": [],
+            },
+        ]
+    )
+
+    telegram = _StubTelegram()
+
+    context = ChannelContext(
+        mapping=ChannelMapping(42, "@chat"),
+        filters=MessageFilters(),
+        customization=MessageCustomization(),
+    )
+
+    await _sync_pins([context], discord, telegram, state, min_delay=0, max_delay=0)
+
+    assert len(telegram.messages) == 1
+    chat_id, text = telegram.messages[0]
+    assert chat_id == "@chat"
+    assert "New pinned" in text
+
+    assert set(state.get_known_pins(42)) == {"101", "202"}


### PR DESCRIPTION
## Summary
- normalise pinned message identifiers to strings before comparison so new pins are detected reliably even when the API returns non-string values
- add a regression test covering pin synchronisation with integer identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cda82a5a20832b8517606d9de68714