### PR TITLE
Handle Telegram errors and harden monitor state

### DIFF
--- a/src/forward_monitor/config.py
+++ b/src/forward_monitor/config.py
@@ -221,6 +221,8 @@ class MonitorConfig:
             telegram_chat_id,
         )
         poll_interval = int(data.get("poll_interval", DEFAULT_POLL_INTERVAL))
+        if poll_interval < 0:
+            raise ValueError("Configuration field 'poll_interval' cannot be negative")
         state_file = _resolve_state_file(path, data.get("state_file"), DEFAULT_STATE_FILE)
         min_message_delay = float(
             data.get("min_message_delay", DEFAULT_MIN_MESSAGE_DELAY)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import textwrap
 
+import pytest
+
 from forward_monitor.config import MonitorConfig
 
 
@@ -46,3 +48,38 @@ def test_default_state_file_uses_config_directory(tmp_path: Path) -> None:
     config = MonitorConfig.from_file(config_path)
 
     assert config.state_file == tmp_path / "monitor_state.json"
+
+
+def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        poll_interval: -5
+        """,
+    )
+
+    with pytest.raises(ValueError):
+        MonitorConfig.from_file(config_path)
+
+
+def test_zero_poll_interval_allowed(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        poll_interval: 0
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+
+    assert config.poll_interval == 0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from typing import Callable
+
+import pytest
 
 import forward_monitor.state as state_module
 
@@ -42,3 +45,55 @@ def test_monitor_state_writes_only_when_dirty(tmp_path) -> None:
         assert call_count == 2
     finally:
         state_module.json.dump = real_dump  # type: ignore[assignment]
+
+
+def test_load_rotates_backup_without_collision(tmp_path) -> None:
+    state_path = tmp_path / "state.json"
+    backup_path = state_path.with_suffix(".bak")
+
+    state_path.write_text("{not json}", encoding="utf-8")
+    state_module.MonitorState(state_path)
+
+    assert backup_path.exists()
+    first_backup = backup_path.read_text(encoding="utf-8")
+
+    state_path.write_text("{still not json}", encoding="utf-8")
+    state_module.MonitorState(state_path)
+
+    assert backup_path.exists()
+    assert backup_path.read_text(encoding="utf-8") == "{still not json}"
+    assert not state_path.exists()
+    assert first_backup != backup_path.read_text(encoding="utf-8")
+
+
+def test_monitor_state_atomic_save(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_path = tmp_path / "state.json"
+    monitor_state = state_module.MonitorState(state_path)
+    monitor_state.update_last_message_id(123, "456")
+    monitor_state.save()
+
+    original_contents = state_path.read_text(encoding="utf-8")
+    monitor_state.update_last_message_id(123, "789")
+
+    real_replace = state_module.Path.replace
+    call_count = 0
+
+    def flaky_replace(self, target):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1 and self.name.endswith(".tmp"):
+            raise OSError("simulated failure")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(state_module.Path, "replace", flaky_replace, raising=False)
+
+    with pytest.raises(OSError):
+        monitor_state.save()
+
+    assert state_path.read_text(encoding="utf-8") == original_contents
+    assert not state_path.with_name("state.json.tmp").exists()
+
+    monitor_state.save()
+
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    assert data["last_message_ids"]["123"] == "789"


### PR DESCRIPTION
## Summary
- raise configuration errors when poll_interval is negative and add regression tests
- surface Telegram Bot API "ok": false responses to callers and verify the behaviour in tests
- make monitor state persistence resilient by atomically replacing files and rotating corrupted backups safely with coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdb7142528832ba46daea6252f93f8