### PR TITLE
Improve formatter handling and add overflow guards

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import sys
 from pathlib import Path
 
 
+pytest_plugins = ["pytest_asyncio"]
+
+
 def _ensure_src_on_path() -> None:
     root = Path(__file__).resolve().parents[1]
     src = root / "src"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from forward_monitor.formatter import (
+    AttachmentInfo,
+    FormattedMessage,
+    clean_discord_content,
+    format_announcement_message,
+)
+
+
+def test_clean_discord_content_preserves_literal_underscores() -> None:
+    message = {"content": "release_candidate"}
+
+    assert clean_discord_content(message) == "release_candidate"
+
+
+def test_clean_discord_content_preserves_literal_backticks() -> None:
+    message = {"content": "literal`backtick"}
+
+    assert clean_discord_content(message) == "literal`backtick"
+
+
+def test_clean_discord_content_strips_markdown_wrappers() -> None:
+    message = {"content": "Look at **bold** and `code` with _italics_"}
+
+    assert (
+        clean_discord_content(message)
+        == "Look at bold and code with italics"
+    )
+
+
+def test_format_includes_embed_data() -> None:
+    message = {
+        "author": {"username": "Tester"},
+        "guild_id": 123,
+        "id": 456,
+        "embeds": [
+            {
+                "title": "Update title",
+                "description": "Details with _markdown_",
+                "fields": [
+                    {"name": "Field", "value": "Some `value`"},
+                ],
+                "footer": {"text": "Footer text"},
+                "author": {"name": "Embed Author"},
+            }
+        ],
+    }
+
+    result = format_announcement_message(789, message, "", [])
+
+    assert isinstance(result, FormattedMessage)
+    assert "Update title" in result.text
+    assert "Details with markdown" in result.text
+    assert "Field: Some value" in result.text
+    assert "Footer text" in result.text
+    assert "Embed Author" in result.text
+    assert result.extra_messages == ()
+
+
+def test_format_keeps_small_attachment_summary_inline() -> None:
+    message = {
+        "author": {"username": "Tester"},
+        "guild_id": 1,
+        "id": 2,
+    }
+    attachments = [
+        AttachmentInfo(
+            url="https://example.com/file.txt",
+            filename="file.txt",
+        )
+    ]
+
+    result = format_announcement_message(3, message, "Body", attachments)
+
+    assert "Вложения:" in result.text
+    assert attachments[0].display_label() in result.text
+    assert result.extra_messages == ()
+
+
+def test_format_splits_oversized_attachment_summary() -> None:
+    message = {
+        "author": {"username": "Tester"},
+        "guild_id": 1,
+        "id": 2,
+    }
+    long_name = "a" * 500
+    attachments = [
+        AttachmentInfo(
+            url=f"https://example.com/{index}",
+            filename=f"{long_name}_{index}",
+        )
+        for index in range(12)
+    ]
+
+    result = format_announcement_message(3, message, "Body", attachments)
+
+    assert len(result.text) <= 4096
+    assert result.extra_messages
+    assert all(len(chunk) <= 4096 for chunk in result.extra_messages)
+
+    combined = "\n".join([result.text, *result.extra_messages])
+    assert "Вложения:" in combined
+    for attachment in attachments:
+        assert attachment.display_label() in combined

--- a/tests/test_monitor_forwarding.py
+++ b/tests/test_monitor_forwarding.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+
+from forward_monitor.config import ChannelMapping, MessageCustomization, MessageFilters
+from forward_monitor.formatter import AttachmentInfo, FormattedMessage
+from forward_monitor.monitor import ChannelContext, _forward_message
+
+
+class StubTelegram:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    async def send_message(self, chat_id: str, text: str) -> None:
+        self.sent.append((chat_id, text))
+
+
+@pytest.mark.asyncio
+async def test_forward_message_sends_extra_messages() -> None:
+    context = ChannelContext(
+        mapping=ChannelMapping(discord_channel_id=1, telegram_chat_id="chat"),
+        filters=MessageFilters().prepare(),
+        customization=MessageCustomization().prepare(),
+    )
+
+    message = {
+        "content": "Hello",
+        "author": {"id": "123"},
+        "id": "456",
+    }
+
+    def formatter(
+        channel_id: int,
+        payload: dict,
+        content: str,
+        attachments: Sequence[AttachmentInfo],
+    ) -> FormattedMessage:
+        assert channel_id == 1
+        assert content == "Hello"
+        assert payload is message
+        assert list(attachments) == []
+        return FormattedMessage("Main", ("Extra one", "Extra two"))
+
+    telegram = StubTelegram()
+
+    await _forward_message(
+        context=context,
+        channel_id=1,
+        message=message,
+        telegram=telegram,
+        formatter=formatter,
+        min_delay=0,
+        max_delay=0,
+    )
+
+    assert telegram.sent == [
+        ("chat", "Main"),
+        ("chat", "Extra one"),
+        ("chat", "Extra two"),
+    ]


### PR DESCRIPTION
## Summary
- add a FormattedMessage container that keeps overflowed attachment summaries in follow-up messages and respects Telegram’s 4096 character limit
- extend the formatter to include embed fields and to only strip real Markdown wrappers while preserving literal underscores/backticks
- exercise the new behaviour with formatter and forwarding tests, and ensure pytest-asyncio is loaded for async test support

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdbab2c2e4832b9df7ef7dbec7a894