### PR TITLE
Improve embed handling and cancellation support

### DIFF
--- a/tests/test_monitor_filters.py
+++ b/tests/test_monitor_filters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from forward_monitor.formatter import AttachmentInfo
+from forward_monitor.formatter import AttachmentInfo, build_attachments, clean_discord_content, extract_embed_text
 from forward_monitor.monitor import _attachment_category, _message_types, _should_forward
 from forward_monitor.config import MessageFilters
 
@@ -26,7 +26,7 @@ def test_should_forward_respects_file_alias_in_filters() -> None:
     message = {"author": {"id": "42"}}
 
     categories = [_attachment_category(attachment)]
-    assert _should_forward(message, "", [attachment], categories, filters)
+    assert _should_forward(message, "", "", [attachment], categories, filters)
 
 
 def test_message_types_include_document_alias() -> None:
@@ -37,7 +37,84 @@ def test_message_types_include_document_alias() -> None:
     )
 
     categories = [_attachment_category(attachment)]
-    types = _message_types("", [attachment], categories)
+    types = _message_types("", "", [attachment], categories)
 
     assert "file" in types
     assert "document" in types
+
+
+def test_should_forward_whitelist_matches_embed_text() -> None:
+    message = {
+        "content": "",
+        "author": {"id": "99"},
+        "embeds": [
+            {
+                "description": "Important Keyword present",
+            }
+        ],
+    }
+
+    filters = MessageFilters(whitelist=["keyword"]).prepare()
+    attachments: list[AttachmentInfo] = []
+    categories: list[str] = []
+    embed_text = extract_embed_text(message)
+
+    assert _should_forward(
+        message,
+        clean_discord_content(message),
+        embed_text,
+        attachments,
+        categories,
+        filters,
+    )
+
+
+def test_should_forward_allowed_types_accepts_embed_text() -> None:
+    message = {
+        "content": "",
+        "author": {"id": "77"},
+        "embeds": [
+            {
+                "description": "Only embed content",
+            }
+        ],
+    }
+
+    filters = MessageFilters(allowed_types=["text"]).prepare()
+    embed_text = extract_embed_text(message)
+    attachments: list[AttachmentInfo] = []
+    categories: list[str] = []
+
+    assert _should_forward(
+        message,
+        clean_discord_content(message),
+        embed_text,
+        attachments,
+        categories,
+        filters,
+    )
+
+
+def test_should_forward_allows_embed_image_attachment() -> None:
+    message = {
+        "content": "",
+        "author": {"id": "55"},
+        "embeds": [
+            {
+                "image": {"url": "https://example.com/picture.png"},
+            }
+        ],
+    }
+
+    filters = MessageFilters(allowed_types=["image"]).prepare()
+    attachments = build_attachments(message)
+    categories = [_attachment_category(attachment) for attachment in attachments]
+
+    assert _should_forward(
+        message,
+        clean_discord_content(message),
+        extract_embed_text(message),
+        attachments,
+        categories,
+        filters,
+    )

--- a/tests/test_monitor_forwarding.py
+++ b/tests/test_monitor_forwarding.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Any, Sequence
 
 import pytest
 
 from forward_monitor.config import ChannelMapping, MessageCustomization, MessageFilters
-from forward_monitor.formatter import AttachmentInfo, FormattedMessage
-from forward_monitor.monitor import ChannelContext, _forward_message
+from forward_monitor.formatter import AttachmentInfo, FormattedMessage, format_announcement_message
+from forward_monitor.monitor import ChannelContext, _forward_message, _sync_announcements
 
 
 class StubTelegram:
@@ -36,11 +36,14 @@ async def test_forward_message_sends_extra_messages() -> None:
         payload: dict,
         content: str,
         attachments: Sequence[AttachmentInfo],
+        *,
+        embed_text: str | None = None,
     ) -> FormattedMessage:
         assert channel_id == 1
         assert content == "Hello"
         assert payload is message
         assert list(attachments) == []
+        assert embed_text == ""
         return FormattedMessage("Main", ("Extra one", "Extra two"))
 
     telegram = StubTelegram()
@@ -59,4 +62,115 @@ async def test_forward_message_sends_extra_messages() -> None:
         ("chat", "Main"),
         ("chat", "Extra one"),
         ("chat", "Extra two"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forward_message_applies_customisation_to_embed_text() -> None:
+    context = ChannelContext(
+        mapping=ChannelMapping(discord_channel_id=2, telegram_chat_id="room"),
+        filters=MessageFilters().prepare(),
+        customization=MessageCustomization(
+            headers=["Header"],
+            footers=["Footer"],
+            replacements={"Secret": "Visible"},
+        ).prepare(),
+    )
+
+    message = {
+        "content": "",
+        "author": {"username": "Author"},
+        "guild_id": 99,
+        "id": 100,
+        "embeds": [
+            {"description": "Secret embed text"},
+        ],
+    }
+
+    telegram = StubTelegram()
+
+    await _forward_message(
+        context=context,
+        channel_id=2,
+        message=message,
+        telegram=telegram,
+        formatter=format_announcement_message,
+        min_delay=0,
+        max_delay=0,
+    )
+
+    assert telegram.sent, "Expected at least one message to be sent"
+    forwarded = telegram.sent[0][1]
+    assert "Header" in forwarded
+    assert "Visible embed text" in forwarded
+    assert forwarded.index("Header") > forwarded.index("канале 2 от Author")
+    footer_position = forwarded.rfind("Footer")
+    assert footer_position != -1
+    jump_index = forwarded.find("Открыть в Discord")
+    assert jump_index == -1 or footer_position < jump_index
+
+
+@pytest.mark.asyncio
+async def test_sync_announcements_fetches_multiple_batches() -> None:
+    context = ChannelContext(
+        mapping=ChannelMapping(discord_channel_id=5, telegram_chat_id="dest"),
+        filters=MessageFilters().prepare(),
+        customization=MessageCustomization().prepare(),
+    )
+
+    first_batch = [
+        {"id": str(index), "author": {"id": "1"}, "content": f"Message {index}"}
+        for index in range(1, 101)
+    ]
+    second_batch = [
+        {"id": "101", "author": {"id": "1"}, "content": "After backlog"},
+        {"id": "102", "author": {"id": "1"}, "content": "Newest"},
+    ]
+
+    class FakeDiscord:
+        def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+            self._batches = batches
+            self.calls: list[tuple[int, str | None, int]] = []
+
+        async def fetch_messages(
+            self,
+            channel_id: int,
+            *,
+            after: str | None = None,
+            limit: int = 100,
+        ) -> list[dict[str, Any]]:
+            self.calls.append((channel_id, after, limit))
+            if self._batches:
+                return self._batches.pop(0)
+            return []
+
+    class DummyState:
+        def __init__(self) -> None:
+            self._values: dict[int, str] = {}
+
+        def get_last_message_id(self, channel_id: int) -> str | None:
+            return self._values.get(channel_id)
+
+        def update_last_message_id(self, channel_id: int, message_id: str) -> None:
+            self._values[channel_id] = message_id
+
+    discord = FakeDiscord([first_batch, second_batch])
+    telegram = StubTelegram()
+    state = DummyState()
+
+    await _sync_announcements(
+        [context],
+        discord,
+        telegram,
+        state,
+        min_delay=0,
+        max_delay=0,
+    )
+
+    # 102 messages should have been forwarded once.
+    assert len(telegram.sent) == 102
+    assert state._values[5] == "102"
+    assert discord.calls == [
+        (5, None, 100),
+        (5, "100", 100),
     ]

--- a/tests/test_monitor_run.py
+++ b/tests/test_monitor_run.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from forward_monitor.config import ChannelMapping, MessageCustomization, MessageFilters, MonitorConfig
+from forward_monitor import monitor
+
+
+class DummySession:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self) -> "DummySession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class DummyDiscordClient:
+    def __init__(self, token: str, session: DummySession) -> None:
+        self.token = token
+        self.session = session
+
+
+class DummyTelegramClient:
+    def __init__(self, token: str, session: DummySession) -> None:
+        self.token = token
+        self.session = session
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_propagates_cancellation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(monitor.aiohttp, "ClientSession", DummySession)
+    monkeypatch.setattr(monitor, "DiscordClient", DummyDiscordClient)
+    monkeypatch.setattr(monitor, "TelegramClient", DummyTelegramClient)
+
+    state_file = tmp_path / "state.json"
+
+    async def fake_sync(
+        contexts,
+        discord,
+        telegram,
+        state,
+        min_delay,
+        max_delay,
+    ) -> None:
+        state.update_last_message_id(123, "456")
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(monitor, "_sync_announcements", fake_sync)
+
+    config = MonitorConfig(
+        discord_token="token",
+        telegram_token="token",
+        telegram_chat_id="chat",
+        announcement_channels=[
+            ChannelMapping(
+                discord_channel_id=123,
+                telegram_chat_id="chat",
+                filters=MessageFilters(),
+                customization=MessageCustomization(),
+            )
+        ],
+        poll_interval=1,
+        state_file=state_file,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await monitor.run_monitor(config)
+
+    assert state_file.exists()
+    with state_file.open("r", encoding="utf-8") as file:
+        data = json.load(file)
+    assert data["last_message_ids"]["123"] == "456"


### PR DESCRIPTION
## Summary
- add embed text extraction and reuse it throughout the monitor so keyword/type filters and customisation include embed-only content
- expand attachment building to include media URLs from embeds while avoiding duplicates, and adjust text cleaning to preserve indentation
- handle Discord backlogs by paging fetches, propagate monitor cancellation cleanly, and add extensive tests covering embeds, cancellation, and batching

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdc0216de4832baf38a09aa2bca43c