### PR TITLE
Allow configuring Discord token type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ python -m forward_monitor --config config.yml
 
 ```yaml
 discord_token: "DISCORD_USER_TOKEN"
+discord_token_type: user  # auto, user, bot или bearer
 telegram_token: "TELEGRAM_BOT_TOKEN"
 telegram_chat_id: "@fallback_channel"  # используется, если у канала нет собственного чата
 
@@ -28,6 +29,10 @@ announcement_channels:
     display_name: "#announcements"  # человеко-читаемый заголовок в сообщении
   - discord_channel_id: 234567890123456789  # сообщения уйдут в fallback-чат
 ```
+
+Поле `discord_token_type` задаёт формат токена: `user` для пользовательских токенов,
+`bot` для токенов ботов без префикса, `bearer` для OAuth и `auto` (по умолчанию),
+который пытается угадать нужный вариант и сохраняет обратную совместимость.
 
 Опционально доступны глобальные фильтры и кастомизация текста. Их можно переопределять на уровне отдельного канала.
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -2,6 +2,7 @@
 # Переименуйте файл и заполните токены/ID перед запуском
 
 discord_token: "DISCORD_USER_TOKEN"
+discord_token_type: auto  # варианты: auto, user, bot, bearer
 telegram_token: "TELEGRAM_BOT_TOKEN"
 telegram_chat_id: "@default_channel_or_chat_id"
 

--- a/src/forward_monitor/monitor.py
+++ b/src/forward_monitor/monitor.py
@@ -162,9 +162,14 @@ async def run_monitor(config: MonitorConfig, *, once: bool = False) -> None:
                 config.discord_token,
                 session,
                 max_concurrency=_DEFAULT_DISCORD_CONCURRENCY,
+                token_type=config.discord_token_type,
             )
         except TypeError:
-            discord = DiscordClient(config.discord_token, session)
+            discord = DiscordClient(
+                config.discord_token,
+                session,
+                token_type=config.discord_token_type,
+            )
         telegram = TelegramClient(config.telegram_token, session)
 
         announcement_contexts = _channel_contexts(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,23 @@ def test_default_state_file_uses_config_directory(tmp_path: Path) -> None:
     assert config.state_file == tmp_path / "monitor_state.json"
 
 
+def test_discord_token_type_defaults_to_auto(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+
+    assert config.discord_token_type == "auto"
+
+
 def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
 
@@ -60,6 +77,23 @@ def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
         telegram_token: telegram
         telegram_chat_id: "@chat"
         poll_interval: -5
+        """,
+    )
+
+    with pytest.raises(ValueError):
+        MonitorConfig.from_file(config_path)
+
+
+def test_discord_token_type_invalid_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        discord_token_type: something
         """,
     )
 
@@ -83,6 +117,24 @@ def test_zero_poll_interval_allowed(tmp_path: Path) -> None:
     config = MonitorConfig.from_file(config_path)
 
     assert config.poll_interval == 0
+
+
+def test_discord_token_type_normalized(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+
+    _write_config(
+        config_path,
+        """
+        discord_token: discord
+        telegram_token: telegram
+        telegram_chat_id: "@chat"
+        discord_token_type: BOT
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+
+    assert config.discord_token_type == "bot"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_monitor_run.py
+++ b/tests/test_monitor_run.py
@@ -34,9 +34,15 @@ class DummySession:
 
 
 class DummyDiscordClient:
-    def __init__(self, token: str, session: DummySession) -> None:
+    def __init__(
+        self,
+        token: str,
+        session: DummySession,
+        **kwargs: object,
+    ) -> None:
         self.token = token
         self.session = session
+        self.kwargs = kwargs
 
 
 class DummyTelegramClient:


### PR DESCRIPTION
## Summary
- add a `discord_token_type` option to the monitor configuration with validation and defaults
- pass the configured token type to the Discord client and expand its header normalisation logic
- document the new option and cover parsing and client behaviour with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2a28bfc38832b99a97a815df95cd9