### PR TITLE
Fix forwarded message accounting when filters skip events

### DIFF
--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -12,6 +12,7 @@ from forward_monitor.discord_client import (
     DISCORD_API_BASE,
     DiscordAPIError,
     DiscordClient,
+    TokenType,
     _normalize_authorization_header,
 )
 
@@ -109,7 +110,7 @@ async def test_fetch_messages_sorts_results_and_passes_params(
     ],
 )
 def test_normalize_authorization_header_variants(
-    token: str, token_type: str, expected: str
+    token: str, token_type: TokenType, expected: str
 ) -> None:
     assert _normalize_authorization_header(token, token_type) == expected
 


### PR DESCRIPTION
## Summary
- ensure `_sync_announcements` only increments forwarded counters and advances state for successfully processed messages
- make `_forward_message` return whether Telegram delivery happened and stop advancing state after delivery failures
- extend tests to cover the new behaviour and tighten mypy expectations

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d2a9102c28832ba0684506ae89ebd2