### PR TITLE
Complete refactor of config, networking, and tests

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,51 +1,77 @@
 # Пример конфигурации для forward_monitor
 # Переименуйте файл и заполните токены/ID перед запуском
 
-discord_token: "DISCORD_USER_TOKEN"
-discord_token_type: auto  # варианты: auto, user, bot, bearer
-telegram_token: "TELEGRAM_BOT_TOKEN"
-telegram_chat_id: "@default_channel_or_chat_id"
+telegram:
+  token: "TELEGRAM_BOT_TOKEN"
+  chat: "@default_channel_or_chat_id"
+  formatting:
+    parse_mode: HTML
+    disable_preview: true
+    attachments: minimal
 
-filters:
-  whitelist:
-    - "airdrop"
-  blacklist:
-    - "maintenance"
-  blocked_senders:
-    - "spammer123"
-  allowed_types:
-    - text
-    - image
-  blocked_types:
-    - audio
+discord:
+  token: "DISCORD_USER_TOKEN"
+  token_type: auto  # варианты: auto, user, bot, bearer
+  rate_limit:
+    per_second: 3.5
+    per_minute: 60
+    concurrency: 4
 
-customization:
-  headers:
-    - "🔥 Важные новости"
-    - "#HashTag"
-  footers:
-    - "— Forward Bot"
-  replacements:
-    OG: "Original"
-    "[скрыть]": ""
+network:
+  user_agents:
+    mobile_ratio: 0.35
+  proxies:
+    pool:
+      - "http://proxy.example:8080"
+    telegram:
+      pool:
+        - "socks5://tg-proxy.example:9050"
+    healthcheck:
+      url: "https://www.google.com/generate_204"
+      timeout: 5
+      cooldown: 180
 
-announcement_channels:
-  - discord_channel_id: 123456789012345678
-    telegram_chat_id: "-1001234567890"
-    display_name: "Основной канал"
+forward:
+  defaults:
     filters:
-      blacklist:
-        - "maintenance"
-    customization:
-      headers: ["📢 Анонсы"]
+      whitelist:
+        - "airdrop"
+      blocked_senders:
+        - "spammer123"
+      allowed_types:
+        - text
+        - image
+    text:
+      chips:
+        - "🔥"
+      headers:
+        - "Важные новости"
+      footers:
+        - "Forward Bot"
       replacements:
-        - find: "LFG"
-          replace: "Let's go"
-        - find: "[link]"
-          replace: ""
-  - discord_channel_id: 223456789012345678  # будет использовать chat_id по умолчанию
+        OG: "Original"
+        "[скрыть]": ""
+    formatting:
+      attachments: compact
+  channels:
+    - discord: 123456789012345678
+      telegram: "-1001234567890"
+      name: "Основной канал"
+      filters:
+        blacklist:
+          - "maintenance"
+      text:
+        headers: ["📢 Анонсы"]
+        replacements:
+          - find: "LFG"
+            replace: "Let's go"
+          - find: "[link]"
+            replace: ""
+    - discord: 223456789012345678  # будет использовать chat по умолчанию
 
-poll_interval: 300  # интервал проверки в секундах
-state_file: "monitor_state.json"
-min_message_delay: 0.5  # минимальная пауза между отправками (сек)
-max_message_delay: 2.0  # максимальная пауза между отправками (сек)
+runtime:
+  poll_every: 300
+  state_file: "monitor_state.json"
+  delays:
+    min: 0.6
+    max: 2.5

--- a/src/forward_monitor/config.py
+++ b/src/forward_monitor/config.py
@@ -2,35 +2,39 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from itertools import chain
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, MutableMapping, cast
 
 from yaml import safe_load
 
-from .discord_client import TokenType
+TokenType = Literal["auto", "bot", "user", "bearer"]
 
 DEFAULT_POLL_INTERVAL: Final[int] = 300
 DEFAULT_STATE_FILE: Final[Path] = Path("monitor_state.json")
 DEFAULT_MIN_MESSAGE_DELAY: Final[float] = 0.5
 DEFAULT_MAX_MESSAGE_DELAY: Final[float] = 2.0
-_ALLOWED_TOKEN_TYPES: tuple[TokenType, ...] = ("auto", "bot", "user", "bearer")
 
+_DEFAULT_TELEGRAM_MESSAGE_LIMIT: Final[int] = 3500
+_TELEGRAM_MAX_LIMIT: Final[int] = 4096
 
-def _normalize_token_type(value: object) -> TokenType:
-    candidate = "auto" if value is None else str(value).strip().lower()
-    if not candidate:
-        candidate = "auto"
+_DEFAULT_DESKTOP_AGENTS: Final[tuple[str, ...]] = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/16.5 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+)
 
-    if candidate not in _ALLOWED_TOKEN_TYPES:
-        allowed = ", ".join(_ALLOWED_TOKEN_TYPES)
-        raise ValueError(
-            f"Configuration field 'discord_token_type' must be one of: {allowed}"
-        )
+_DEFAULT_MOBILE_AGENTS: Final[tuple[str, ...]] = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+    "Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36",
+)
 
-    return cast(TokenType, candidate)
-
-SUPPORTED_MESSAGE_TYPES: frozenset[str] = frozenset(
+_VALID_MESSAGE_TYPES: Final[frozenset[str]] = frozenset(
     {
         "text",
         "attachment",
@@ -48,18 +52,186 @@ __all__ = [
     "DEFAULT_STATE_FILE",
     "DEFAULT_MIN_MESSAGE_DELAY",
     "DEFAULT_MAX_MESSAGE_DELAY",
-    "ChannelMapping",
+    "TokenType",
     "MessageFilters",
     "PreparedFilters",
     "MessageCustomization",
     "PreparedCustomization",
+    "CustomisedText",
+    "FormattingProfile",
+    "RateLimitSettings",
+    "ProxyPoolSettings",
+    "UserAgentSettings",
+    "ChannelDefaults",
+    "ChannelMapping",
+    "MonitorRuntime",
+    "DiscordSettings",
+    "TelegramSettings",
+    "NetworkSettings",
     "MonitorConfig",
 ]
 
 
 @dataclass(frozen=True, slots=True)
+class RateLimitSettings:
+    """Soft rate-limit policy used when communicating with external services."""
+
+    per_second: float | None = None
+    per_minute: int | None = 60
+    concurrency: int = 4
+    jitter_min_ms: int = 40
+    jitter_max_ms: int = 160
+    cooldown_seconds: float = 30.0
+
+    def merge(self, other: RateLimitSettings | None) -> RateLimitSettings:
+        if other is None:
+            return self
+        return RateLimitSettings(
+            per_second=_first_non_null(other.per_second, self.per_second),
+            per_minute=_first_non_null(other.per_minute, self.per_minute),
+            concurrency=max(1, _first_non_null(other.concurrency, self.concurrency)),
+            jitter_min_ms=max(0, _first_non_null(other.jitter_min_ms, self.jitter_min_ms)),
+            jitter_max_ms=max(
+                _first_non_null(other.jitter_max_ms, self.jitter_max_ms),
+                _first_non_null(other.jitter_min_ms, self.jitter_min_ms),
+            ),
+            cooldown_seconds=max(
+                0.0,
+                float(
+                    _first_non_null(
+                        other.cooldown_seconds,
+                        self.cooldown_seconds,
+                    )
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyPoolSettings:
+    """Definition of an outbound proxy pool."""
+
+    endpoints: tuple[str, ...] = ()
+    health_check_url: str | None = None
+    health_check_timeout: float = 5.0
+    recovery_seconds: float = 180.0
+
+    def merge(self, other: ProxyPoolSettings | None) -> ProxyPoolSettings:
+        if other is None:
+            return self
+        endpoints = _merge_sequences(self.endpoints, other.endpoints)
+        health_check_url = other.health_check_url or self.health_check_url
+        timeout = float(
+            _first_non_null(other.health_check_timeout, self.health_check_timeout)
+        )
+        recovery = float(_first_non_null(other.recovery_seconds, self.recovery_seconds))
+        return ProxyPoolSettings(
+            endpoints=endpoints,
+            health_check_url=health_check_url,
+            health_check_timeout=max(timeout, 0.1),
+            recovery_seconds=max(recovery, 1.0),
+        )
+
+    def normalised(self) -> ProxyPoolSettings:
+        cleaned = tuple({endpoint.strip(): None for endpoint in self.endpoints if endpoint}.keys())
+        return ProxyPoolSettings(
+            endpoints=cleaned,
+            health_check_url=(self.health_check_url or "").strip() or None,
+            health_check_timeout=self.health_check_timeout,
+            recovery_seconds=self.recovery_seconds,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class UserAgentSettings:
+    """Pools of desktop and mobile user-agent strings."""
+
+    desktop: tuple[str, ...] = _DEFAULT_DESKTOP_AGENTS
+    mobile: tuple[str, ...] = _DEFAULT_MOBILE_AGENTS
+    mobile_ratio: float = 0.35
+
+    def normalised(self) -> UserAgentSettings:
+        mobile_ratio = min(max(float(self.mobile_ratio), 0.0), 1.0)
+        desktop = _deduplicate(self.desktop, fallback=_DEFAULT_DESKTOP_AGENTS)
+        mobile = _deduplicate(self.mobile, fallback=_DEFAULT_MOBILE_AGENTS)
+        return UserAgentSettings(desktop=desktop, mobile=mobile, mobile_ratio=mobile_ratio)
+
+
+@dataclass(frozen=True, slots=True)
+class FormattingProfile:
+    """Controls Telegram specific formatting options."""
+
+    parse_mode: str = "HTML"
+    disable_link_preview: bool = True
+    max_length: int = _DEFAULT_TELEGRAM_MESSAGE_LIMIT
+    ellipsis: str = "…"
+    attachments_style: Literal["compact", "minimal"] = "minimal"
+    provided: frozenset[str] = field(
+        default_factory=frozenset, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        if self.provided:
+            return
+        explicit: set[str] = set()
+        if self.parse_mode != "HTML":
+            explicit.add("parse_mode")
+        if self.disable_link_preview is not True:
+            explicit.add("disable_link_preview")
+        if self.max_length != _DEFAULT_TELEGRAM_MESSAGE_LIMIT:
+            explicit.add("max_length")
+        if self.ellipsis != "…":
+            explicit.add("ellipsis")
+        if self.attachments_style != "minimal":
+            explicit.add("attachments_style")
+        if explicit:
+            object.__setattr__(self, "provided", frozenset(explicit))
+
+    def merge(self, other: FormattingProfile | None) -> FormattingProfile:
+        if other is None:
+            return self
+        values = {
+            "parse_mode": self.parse_mode,
+            "disable_link_preview": self.disable_link_preview,
+            "max_length": self.max_length,
+            "ellipsis": self.ellipsis,
+            "attachments_style": self.attachments_style,
+        }
+        explicit = set(self.provided)
+
+        if "parse_mode" in other.provided:
+            values["parse_mode"] = (other.parse_mode or self.parse_mode or "").strip() or "HTML"
+            explicit.add("parse_mode")
+        if "disable_link_preview" in other.provided:
+            disable = bool(
+                _first_non_null(other.disable_link_preview, self.disable_link_preview)
+            )
+            values["disable_link_preview"] = disable
+            explicit.add("disable_link_preview")
+        if "max_length" in other.provided:
+            max_length = max(
+                100,
+                min(
+                    int(_first_non_null(other.max_length, self.max_length)),
+                    _TELEGRAM_MAX_LIMIT,
+                ),
+            )
+            values["max_length"] = max_length
+            explicit.add("max_length")
+        if "ellipsis" in other.provided:
+            ellipsis = (other.ellipsis or self.ellipsis or "").strip() or "…"
+            values["ellipsis"] = ellipsis
+            explicit.add("ellipsis")
+        if "attachments_style" in other.provided:
+            values["attachments_style"] = other.attachments_style or self.attachments_style
+            explicit.add("attachments_style")
+
+        return FormattingProfile(**values, provided=frozenset(explicit))
+
+
+@dataclass(frozen=True, slots=True)
 class MessageFilters:
-    """Keyword and sender based filters for forwarded messages."""
+    """Keyword, sender and attachment filters applied to forwarded messages."""
 
     whitelist: Sequence[str] = ()
     blacklist: Sequence[str] = ()
@@ -71,12 +243,8 @@ class MessageFilters:
     def __post_init__(self) -> None:
         object.__setattr__(self, "whitelist", _freeze_sequence(self.whitelist))
         object.__setattr__(self, "blacklist", _freeze_sequence(self.blacklist))
-        object.__setattr__(
-            self, "allowed_senders", _freeze_sequence(self.allowed_senders)
-        )
-        object.__setattr__(
-            self, "blocked_senders", _freeze_sequence(self.blocked_senders)
-        )
+        object.__setattr__(self, "allowed_senders", _freeze_sequence(self.allowed_senders))
+        object.__setattr__(self, "blocked_senders", _freeze_sequence(self.blocked_senders))
         object.__setattr__(self, "allowed_types", _freeze_sequence(self.allowed_types))
         object.__setattr__(self, "blocked_types", _freeze_sequence(self.blocked_types))
 
@@ -90,7 +258,6 @@ class MessageFilters:
                 allowed_types=self.allowed_types,
                 blocked_types=self.blocked_types,
             )
-
         return MessageFilters(
             whitelist=_merge_sequences(self.whitelist, other.whitelist),
             blacklist=_merge_sequences(self.blacklist, other.blacklist),
@@ -101,15 +268,12 @@ class MessageFilters:
         )
 
     def prepare(self) -> PreparedFilters:
-        """Materialise frequently used filter data in an efficient form."""
-
         whitelist = tuple(_casefold_unique(self.whitelist))
         blacklist = tuple(_casefold_unique(self.blacklist))
         allowed_senders = frozenset(_casefold_unique(self.allowed_senders))
         blocked_senders = frozenset(_casefold_unique(self.blocked_senders))
         allowed_types = frozenset(_casefold_unique(self.allowed_types))
         blocked_types = frozenset(_casefold_unique(self.blocked_types))
-
         return PreparedFilters(
             whitelist=whitelist,
             blacklist=blacklist,
@@ -124,8 +288,6 @@ class MessageFilters:
 
 @dataclass(frozen=True, slots=True)
 class PreparedFilters:
-    """Immutable, case-folded filters ready for matching."""
-
     whitelist: tuple[str, ...]
     blacklist: tuple[str, ...]
     allowed_senders: frozenset[str]
@@ -138,13 +300,15 @@ class PreparedFilters:
 
 @dataclass(frozen=True, slots=True)
 class MessageCustomization:
-    """Rules that customise the textual part of forwarded messages."""
+    """Textual customisation applied before Telegram formatting."""
 
+    chips: Sequence[str] = ()
     headers: Sequence[str] = ()
     footers: Sequence[str] = ()
     replacements: Sequence[tuple[str, str]] = ()
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "chips", _freeze_sequence(self.chips))
         object.__setattr__(self, "headers", _freeze_sequence(self.headers))
         object.__setattr__(self, "footers", _freeze_sequence(self.footers))
         object.__setattr__(self, "replacements", _freeze_replacements(self.replacements))
@@ -152,407 +316,566 @@ class MessageCustomization:
     def combine(self, other: MessageCustomization | None) -> MessageCustomization:
         if other is None:
             return MessageCustomization(
+                chips=self.chips,
                 headers=self.headers,
                 footers=self.footers,
                 replacements=self.replacements,
             )
-
-        merged_replacements: dict[str, str] = dict(self.replacements)
+        merged_replacements: MutableMapping[str, str] = dict(self.replacements)
         merged_replacements.update(dict(other.replacements))
-
         return MessageCustomization(
+            chips=_merge_sequences(self.chips, other.chips),
             headers=_merge_sequences(self.headers, other.headers),
             footers=_merge_sequences(self.footers, other.footers),
             replacements=tuple(merged_replacements.items()),
         )
 
     def prepare(self) -> PreparedCustomization:
-        header_text = "\n".join(segment for segment in self.headers if segment)
-        footer_text = "\n".join(segment for segment in self.footers if segment)
+        chips = tuple(_unique_non_empty(self.chips))
+        headers = tuple(_unique_non_empty(self.headers))
+        footers = tuple(_unique_non_empty(self.footers))
+        replacements = tuple((find, replace) for find, replace in self.replacements if find)
         return PreparedCustomization(
-            header_text=header_text,
-            footer_text=footer_text,
-            replacements=tuple(self.replacements),
+            chips=chips,
+            headers=headers,
+            footers=footers,
+            replacements=replacements,
         )
 
-    def apply(self, content: str) -> str:
-        return self.prepare().apply(content)
+
+@dataclass(frozen=True, slots=True)
+class CustomisedText:
+    chips: tuple[str, ...]
+    header_lines: tuple[str, ...]
+    body_lines: tuple[str, ...]
+    footer_lines: tuple[str, ...]
+
+    def as_string(self) -> str:
+        segments: list[str] = []
+        if self.header_lines:
+            segments.append("\n".join(self.header_lines))
+        if self.body_lines:
+            segments.append("\n".join(self.body_lines))
+        if self.footer_lines:
+            segments.append("\n".join(self.footer_lines))
+        return "\n\n".join(segment for segment in segments if segment)
 
 
 @dataclass(frozen=True, slots=True)
 class PreparedCustomization:
-    """Pre-processed representation of customisation rules."""
-
-    header_text: str
-    footer_text: str
+    chips: tuple[str, ...]
+    headers: tuple[str, ...]
+    footers: tuple[str, ...]
     replacements: tuple[tuple[str, str], ...]
 
-    def apply(self, content: str) -> str:
-        if not (self.header_text or self.footer_text or self.replacements):
-            return content or ""
-
-        result = content or ""
+    def render(self, content: str) -> CustomisedText:
+        text = content or ""
         for find, replace in self.replacements:
-            if not find:
-                continue
-            result = result.replace(find, replace)
+            text = text.replace(find, replace)
+        body_lines = _normalise_multiline(text)
+        return CustomisedText(
+            chips=self.chips,
+            header_lines=self.headers,
+            body_lines=body_lines,
+            footer_lines=self.footers,
+        )
 
-        segments: list[str] = []
-        if self.header_text:
-            segments.append(self.header_text)
-        if result:
-            segments.append(result)
-        if self.footer_text:
-            segments.append(self.footer_text)
 
-        if not segments:
-            return ""
-        if len(segments) == 1:
-            return segments[0]
-        return "\n\n".join(segments)
+@dataclass(frozen=True, slots=True)
+class ChannelDefaults:
+    filters: MessageFilters = field(default_factory=MessageFilters)
+    customization: MessageCustomization = field(default_factory=MessageCustomization)
+    formatting: FormattingProfile = field(default_factory=FormattingProfile)
 
 
 @dataclass(frozen=True, slots=True)
 class ChannelMapping:
-    """Relationship between a Discord channel and a Telegram chat."""
-
     discord_channel_id: int
     telegram_chat_id: str
     display_name: str | None = None
     filters: MessageFilters = field(default_factory=MessageFilters)
     customization: MessageCustomization = field(default_factory=MessageCustomization)
+    formatting: FormattingProfile = field(default_factory=FormattingProfile)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "telegram_chat_id", self.telegram_chat_id.strip())
         if self.display_name is not None:
-            object.__setattr__(
-                self,
-                "display_name",
-                self.display_name.strip() or None,
-            )
+            object.__setattr__(self, "display_name", self.display_name.strip() or None)
+
+
+@dataclass(frozen=True, slots=True)
+class MonitorRuntime:
+    poll_interval: int = DEFAULT_POLL_INTERVAL
+    state_file: Path = DEFAULT_STATE_FILE
+    min_delay: float = DEFAULT_MIN_MESSAGE_DELAY
+    max_delay: float = DEFAULT_MAX_MESSAGE_DELAY
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordSettings:
+    token: str
+    token_type: TokenType = "auto"
+    rate_limit: RateLimitSettings = field(default_factory=RateLimitSettings)
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramSettings:
+    token: str
+    default_chat: str
+    rate_limit: RateLimitSettings = field(default_factory=lambda: RateLimitSettings(per_second=0.9, per_minute=25, concurrency=1))
+    formatting: FormattingProfile = field(default_factory=FormattingProfile)
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkSettings:
+    user_agents: UserAgentSettings = field(default_factory=UserAgentSettings)
+    default_proxy: ProxyPoolSettings = field(default_factory=ProxyPoolSettings)
+    discord_proxy: ProxyPoolSettings = field(default_factory=ProxyPoolSettings)
+    telegram_proxy: ProxyPoolSettings = field(default_factory=ProxyPoolSettings)
+
+    def proxy_for_service(self, service: str) -> ProxyPoolSettings:
+        base = self.default_proxy.normalised()
+        if service == "discord":
+            return base.merge(self.discord_proxy).normalised()
+        if service == "telegram":
+            return base.merge(self.telegram_proxy).normalised()
+        return base
 
 
 @dataclass(frozen=True, slots=True)
 class MonitorConfig:
-    """Configuration for the Discord to Telegram monitor."""
-
-    discord_token: str
-    telegram_token: str
-    telegram_chat_id: str
-    discord_token_type: TokenType = "auto"
-    announcement_channels: Sequence[ChannelMapping] = ()
-    poll_interval: int = DEFAULT_POLL_INTERVAL
-    state_file: Path = DEFAULT_STATE_FILE
-    min_message_delay: float = DEFAULT_MIN_MESSAGE_DELAY
-    max_message_delay: float = DEFAULT_MAX_MESSAGE_DELAY
-    filters: MessageFilters = field(default_factory=MessageFilters)
-    customization: MessageCustomization = field(default_factory=MessageCustomization)
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "discord_token", self.discord_token.strip())
-        object.__setattr__(
-            self,
-            "discord_token_type",
-            _normalize_token_type(self.discord_token_type),
-        )
-        object.__setattr__(self, "telegram_token", self.telegram_token.strip())
-        object.__setattr__(self, "telegram_chat_id", self.telegram_chat_id.strip())
-        object.__setattr__(
-            self,
-            "announcement_channels",
-            tuple(self.announcement_channels),
-        )
+    discord: DiscordSettings
+    telegram: TelegramSettings
+    runtime: MonitorRuntime
+    defaults: ChannelDefaults
+    channels: tuple[ChannelMapping, ...]
+    network: NetworkSettings
 
     @classmethod
     def from_file(cls, path: Path) -> MonitorConfig:
-        path = path.expanduser()
-        data = _load_yaml(path)
-        path = path.resolve()
-        try:
-            discord_token = str(data["discord_token"]).strip()
-            telegram_token = str(data["telegram_token"]).strip()
-            telegram_chat_id = str(data["telegram_chat_id"]).strip()
-        except KeyError as exc:  # pragma: no cover - defensive programming
-            missing = exc.args[0]
-            raise ValueError(f"Missing required configuration key: {missing}") from exc
+        raw = _load_yaml(path)
+        path = path.expanduser().resolve()
 
-        token_type = _normalize_token_type(data.get("discord_token_type", "auto"))
+        discord_section = _expect_mapping(raw.get("discord"), "discord")
+        telegram_section = _expect_mapping(raw.get("telegram"), "telegram")
+        forward_section = _expect_mapping(raw.get("forward"), "forward", default={})
+        runtime_section = _expect_mapping(raw.get("runtime"), "runtime", default={})
+        network_section = _expect_mapping(raw.get("network"), "network", default={})
 
-        if not discord_token:
-            raise ValueError("Configuration field 'discord_token' must not be empty")
-        if not telegram_token:
-            raise ValueError("Configuration field 'telegram_token' must not be empty")
-        if not telegram_chat_id:
-            raise ValueError("Configuration field 'telegram_chat_id' must not be empty")
-
-        filters = _parse_filters(data.get("filters"))
-        customization = _parse_customization(data.get("customization"))
-
-        announcement_channels = tuple(
-            _coerce_channel_mappings(
-                data.get("announcement_channels", []),
-                "announcement_channels",
-                telegram_chat_id,
-            )
+        discord = _parse_discord_settings(discord_section)
+        telegram = _parse_telegram_settings(telegram_section)
+        defaults = _parse_defaults(forward_section.get("defaults"))
+        merged_formatting = telegram.formatting.merge(defaults.formatting)
+        defaults = ChannelDefaults(
+            filters=defaults.filters,
+            customization=defaults.customization,
+            formatting=merged_formatting,
         )
 
-        poll_interval = int(data.get("poll_interval", DEFAULT_POLL_INTERVAL))
-        if poll_interval < 0:
-            raise ValueError("Configuration field 'poll_interval' cannot be negative")
-        state_file = _resolve_state_file(path, data.get("state_file"), DEFAULT_STATE_FILE)
-        min_message_delay = float(data.get("min_message_delay", DEFAULT_MIN_MESSAGE_DELAY))
-        max_message_delay = float(data.get("max_message_delay", DEFAULT_MAX_MESSAGE_DELAY))
+        channels = tuple(
+            _parse_channel_mapping(entry, telegram.default_chat, defaults)
+            for entry in _expect_sequence(forward_section.get("channels"), "forward.channels")
+        )
 
-        if min_message_delay < 0:
-            raise ValueError("Configuration field 'min_message_delay' cannot be negative")
-        if max_message_delay < min_message_delay:
-            raise ValueError(
-                "Configuration field 'max_message_delay' must be greater than or equal to "
-                "'min_message_delay'",
-            )
+        runtime = _parse_runtime(runtime_section, path)
+        network = _parse_network_settings(network_section)
 
         return cls(
-            discord_token=discord_token,
-            discord_token_type=token_type,
-            telegram_token=telegram_token,
-            telegram_chat_id=telegram_chat_id,
-            announcement_channels=announcement_channels,
-            poll_interval=poll_interval,
-            state_file=state_file,
-            min_message_delay=min_message_delay,
-            max_message_delay=max_message_delay,
-            filters=filters,
-            customization=customization,
+            discord=discord,
+            telegram=telegram,
+            runtime=runtime,
+            defaults=defaults,
+            channels=channels,
+            network=network,
         )
 
 
-def _load_yaml(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {path}")
-
-    with path.open("r", encoding="utf-8") as file:
-        data = safe_load(file) or {}
-
-    if not isinstance(data, Mapping):  # pragma: no cover - configuration error path
-        raise ValueError("Configuration file must contain a mapping at the top level")
-    return dict(data)
+def _parse_discord_settings(raw: Mapping[str, Any]) -> DiscordSettings:
+    token = _require_string(raw, "discord.token", raw.get("token"))
+    token_type = _normalize_token_type(raw.get("token_type"))
+    rate_limit = _parse_rate_limit(raw.get("rate_limit"), fallback=RateLimitSettings(per_second=4.0, per_minute=60, concurrency=4))
+    return DiscordSettings(token=token, token_type=token_type, rate_limit=rate_limit)
 
 
-def _coerce_channel_mappings(
-    value: Iterable[object], field_name: str, default_chat_id: str
-) -> list[ChannelMapping]:
-    if value is None:
-        return []
-
-    if not isinstance(value, list):
-        raise ValueError(f"Configuration field '{field_name}' must be a list")
-
-    mappings: list[ChannelMapping] = []
-    for item in value:
-        if isinstance(item, Mapping):
-            discord_raw = item.get("discord_channel_id") or item.get("discord")
-            telegram_raw = item.get("telegram_chat_id") or item.get("telegram")
-            if discord_raw is None:
-                raise ValueError(
-                    f"Configuration field '{field_name}' entries must specify 'discord_channel_id'"
-                )
-            channel_id = _coerce_channel_id(discord_raw, field_name)
-            fallback_chat = default_chat_id
-            telegram_chat_source = fallback_chat if telegram_raw is None else telegram_raw
-            telegram_chat = str(telegram_chat_source).strip()
-            if not telegram_chat:
-                raise ValueError(
-                    "Configuration field "
-                    f"'{field_name}' entries must specify a non-empty 'telegram_chat_id'",
-                )
-            filters = _parse_filters(item.get("filters"))
-            customization = _parse_customization(item.get("customization"))
-            display_name_raw = item.get("display_name")
-            display_name = None
-            if display_name_raw is not None:
-                display_name = str(display_name_raw).strip() or None
-        else:
-            channel_id = _coerce_channel_id(item, field_name)
-            telegram_chat = str(default_chat_id).strip()
-            if not telegram_chat:
-                raise ValueError(
-                    "Configuration field "
-                    f"'{field_name}' requires a non-empty fallback 'telegram_chat_id'",
-                )
-            filters = MessageFilters()
-            customization = MessageCustomization()
-            display_name = None
-
-        mappings.append(
-            ChannelMapping(
-                channel_id,
-                telegram_chat,
-                display_name,
-                filters,
-                customization,
-            )
-        )
-
-    return mappings
+def _parse_telegram_settings(raw: Mapping[str, Any]) -> TelegramSettings:
+    token = _require_string(raw, "telegram.token", raw.get("token"))
+    chat = _require_string(raw, "telegram.chat", raw.get("chat") or raw.get("chat_id"))
+    base_formatting = _parse_formatting(raw.get("formatting"))
+    rate_limit = _parse_rate_limit(raw.get("rate_limit"), fallback=RateLimitSettings(per_second=0.8, per_minute=25, concurrency=1, jitter_min_ms=60, jitter_max_ms=200))
+    formatting = FormattingProfile().merge(base_formatting)
+    return TelegramSettings(token=token, default_chat=chat, rate_limit=rate_limit, formatting=formatting)
 
 
-def _coerce_channel_id(value: object, field_name: str) -> int:
-    if isinstance(value, bool):  # pragma: no cover - configuration error path
-        raise ValueError(
-            "Configuration field "
-            f"'{field_name}' must contain integers for Discord channel IDs; got {value!r}",
-        )
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            raise ValueError(
-                "Configuration field "
-                f"'{field_name}' must contain integers for Discord channel IDs; got {value!r}",
-            )
-        try:
-            return int(text)
-        except ValueError as exc:  # pragma: no cover - configuration error path
-            raise ValueError(
-                "Configuration field "
-                f"'{field_name}' must contain integers for Discord channel IDs; got {value!r}",
-            ) from exc
-    raise ValueError(
-        "Configuration field "
-        f"'{field_name}' must contain integers for Discord channel IDs; got {value!r}",
+def _parse_defaults(raw: Any) -> ChannelDefaults:
+    if raw is None:
+        return ChannelDefaults()
+    if not isinstance(raw, Mapping):
+        raise ValueError("Configuration field 'forward.defaults' must be a mapping")
+    filters = _parse_filters(raw.get("filters"), context="forward.defaults.filters")
+    customization = _parse_customization(raw.get("text") or raw.get("customization"))
+    formatting = _parse_formatting(raw.get("formatting"))
+    return ChannelDefaults(
+        filters=filters,
+        customization=customization,
+        formatting=FormattingProfile().merge(formatting),
     )
 
 
-def _parse_filters(raw: object) -> MessageFilters:
+def _parse_channel_mapping(
+    raw: Any,
+    default_chat: str,
+    defaults: ChannelDefaults,
+) -> ChannelMapping:
+    if not isinstance(raw, Mapping):
+        raise ValueError("Each entry in 'forward.channels' must be a mapping")
+    discord_id = _coerce_channel_id(raw.get("discord"), "forward.channels.discord")
+    telegram_chat_raw = raw.get("telegram") or raw.get("chat") or default_chat
+    telegram_chat = _require_string(raw, "forward.channels.telegram", telegram_chat_raw)
+    display_name = _optional_string(raw.get("name") or raw.get("label"))
+    filter_context = f"forward.channels[{discord_id}].filters"
+    filters = defaults.filters.combine(
+        _parse_filters(raw.get("filters"), context=filter_context)
+    )
+    customization = defaults.customization.combine(
+        _parse_customization(raw.get("text") or raw.get("customization"))
+    )
+    formatting = defaults.formatting.merge(_parse_formatting(raw.get("formatting")))
+    return ChannelMapping(
+        discord_channel_id=discord_id,
+        telegram_chat_id=telegram_chat,
+        display_name=display_name,
+        filters=filters,
+        customization=customization,
+        formatting=formatting,
+    )
+
+
+def _parse_runtime(raw: Mapping[str, Any], config_path: Path) -> MonitorRuntime:
+    poll_interval = int(_first_non_null(raw.get("poll_every"), DEFAULT_POLL_INTERVAL))
+    if poll_interval < 0:
+        raise ValueError("Configuration field 'runtime.poll_every' cannot be negative")
+
+    delays_raw = raw.get("delays")
+    if delays_raw is None:
+        delays_map: Mapping[str, Any] = {}
+    elif isinstance(delays_raw, Mapping):
+        delays_map = delays_raw
+    else:
+        raise ValueError("Configuration field 'runtime.delays' must be a mapping if provided")
+
+    min_delay = float(_first_non_null(delays_map.get("min"), DEFAULT_MIN_MESSAGE_DELAY))
+    max_delay = float(_first_non_null(delays_map.get("max"), DEFAULT_MAX_MESSAGE_DELAY))
+    if min_delay < 0:
+        raise ValueError("Configuration field 'runtime.delays.min' cannot be negative")
+    if max_delay < min_delay:
+        raise ValueError("Configuration field 'runtime.delays.max' must be greater than or equal to runtime.delays.min")
+    state_raw = raw.get("state_file")
+    state_file = _resolve_state_file(config_path, state_raw, DEFAULT_STATE_FILE)
+    return MonitorRuntime(
+        poll_interval=poll_interval,
+        state_file=state_file,
+        min_delay=min_delay,
+        max_delay=max_delay,
+    )
+
+
+def _parse_network_settings(raw: Mapping[str, Any]) -> NetworkSettings:
+    proxies = raw.get("proxies")
+    if proxies is None:
+        proxies_mapping: Mapping[str, Any] = {}
+    elif isinstance(proxies, Mapping):
+        proxies_mapping = proxies
+    else:
+        raise ValueError("Configuration field 'network.proxies' must be a mapping")
+
+    default_proxy = _parse_proxy_pool(proxies_mapping.get("pool"))
+    discord_proxy = _parse_proxy_pool(proxies_mapping.get("discord"))
+    telegram_proxy = _parse_proxy_pool(proxies_mapping.get("telegram"))
+
+    if isinstance(proxies_mapping.get("healthcheck"), Mapping):
+        health_map = cast(Mapping[str, Any], proxies_mapping.get("healthcheck"))
+        base = ProxyPoolSettings(
+            health_check_url=_optional_string(health_map.get("url")),
+            health_check_timeout=float(health_map.get("timeout", 5.0)),
+            recovery_seconds=float(health_map.get("cooldown", 180.0)),
+        )
+        default_proxy = default_proxy.merge(base)
+        discord_proxy = discord_proxy.merge(base)
+        telegram_proxy = telegram_proxy.merge(base)
+
+    user_agents = _parse_user_agents(raw.get("user_agents"))
+
+    return NetworkSettings(
+        user_agents=user_agents.normalised(),
+        default_proxy=default_proxy.normalised(),
+        discord_proxy=discord_proxy.normalised(),
+        telegram_proxy=telegram_proxy.normalised(),
+    )
+
+
+def _parse_proxy_pool(raw: Any) -> ProxyPoolSettings:
+    if raw is None:
+        return ProxyPoolSettings()
+    if isinstance(raw, Mapping):
+        endpoints = raw.get("pool") or raw.get("endpoints") or raw.get("urls")
+        health_url = raw.get("healthcheck") or raw.get("health_check")
+        timeout = raw.get("timeout")
+        recovery = raw.get("cooldown") or raw.get("recovery")
+        settings = ProxyPoolSettings(
+            endpoints=tuple(_to_string_list(endpoints)),
+            health_check_url=_optional_string(health_url),
+            health_check_timeout=float(timeout) if timeout is not None else 5.0,
+            recovery_seconds=float(recovery) if recovery is not None else 180.0,
+        )
+        return settings.normalised()
+    if isinstance(raw, Sequence):
+        return ProxyPoolSettings(endpoints=tuple(_to_string_list(raw))).normalised()
+    if isinstance(raw, str):
+        return ProxyPoolSettings(endpoints=(raw.strip(),)).normalised()
+    raise ValueError("Proxy configuration must be a mapping, list or string")
+
+
+def _parse_user_agents(raw: Any) -> UserAgentSettings:
+    if raw is None:
+        return UserAgentSettings().normalised()
+    if not isinstance(raw, Mapping):
+        raise ValueError("Configuration field 'network.user_agents' must be a mapping")
+    desktop = tuple(_to_string_list(raw.get("desktop"))) or _DEFAULT_DESKTOP_AGENTS
+    mobile = tuple(_to_string_list(raw.get("mobile"))) or _DEFAULT_MOBILE_AGENTS
+    ratio_raw = raw.get("mobile_ratio") or raw.get("mobile_share")
+    ratio = float(ratio_raw) if ratio_raw is not None else 0.35
+    return UserAgentSettings(desktop=desktop, mobile=mobile, mobile_ratio=ratio).normalised()
+
+
+def _parse_rate_limit(raw: Any, *, fallback: RateLimitSettings) -> RateLimitSettings:
+    if raw is None:
+        return fallback
+    if not isinstance(raw, Mapping):
+        raise ValueError("Rate limit settings must be provided as a mapping")
+    per_second = raw.get("per_second") or raw.get("rps")
+    per_minute = raw.get("per_minute") or raw.get("rpm")
+    concurrency = raw.get("concurrency")
+    jitter = raw.get("jitter_ms") or raw.get("jitter")
+    if isinstance(jitter, Sequence) and not isinstance(jitter, str):
+        jitter_min, jitter_max = (float(jitter[0]), float(jitter[-1]))
+    else:
+        jitter_value = float(jitter) if jitter is not None else None
+        jitter_min = jitter_max = jitter_value if jitter_value is not None else None
+    cooldown = raw.get("cooldown") or raw.get("cooldown_seconds")
+    settings = RateLimitSettings(
+        per_second=float(per_second) if per_second is not None else fallback.per_second,
+        per_minute=int(per_minute) if per_minute is not None else fallback.per_minute,
+        concurrency=int(concurrency) if concurrency is not None else fallback.concurrency,
+        jitter_min_ms=int(jitter_min) if jitter_min is not None else fallback.jitter_min_ms,
+        jitter_max_ms=int(jitter_max) if jitter_max is not None else fallback.jitter_max_ms,
+        cooldown_seconds=float(cooldown) if cooldown is not None else fallback.cooldown_seconds,
+    )
+    return fallback.merge(settings)
+
+
+def _parse_filters(raw: Any, *, context: str) -> MessageFilters:
     if raw is None:
         return MessageFilters()
-
     if not isinstance(raw, Mapping):
-        raise ValueError("Configuration field 'filters' must be a mapping if provided")
-
-    allowed_types = _to_string_list(raw.get("allowed_types"))
-    blocked_types = _to_string_list(raw.get("blocked_types"))
-    _validate_message_types(allowed_types, "filters.allowed_types")
-    _validate_message_types(blocked_types, "filters.blocked_types")
-
+        raise ValueError("Filter definitions must be mappings")
+    allowed_types_raw = tuple(_to_string_list(raw.get("allowed_types")))
+    blocked_types_raw = tuple(_to_string_list(raw.get("blocked_types")))
+    allowed_types = _validate_message_types(
+        allowed_types_raw, f"{context}.allowed_types"
+    )
+    blocked_types = _validate_message_types(
+        blocked_types_raw, f"{context}.blocked_types"
+    )
     return MessageFilters(
         whitelist=tuple(_to_string_list(raw.get("whitelist"))),
         blacklist=tuple(_to_string_list(raw.get("blacklist"))),
         allowed_senders=tuple(_to_string_list(raw.get("allowed_senders"))),
         blocked_senders=tuple(_to_string_list(raw.get("blocked_senders"))),
-        allowed_types=tuple(allowed_types),
-        blocked_types=tuple(blocked_types),
+        allowed_types=allowed_types,
+        blocked_types=blocked_types,
     )
 
 
-def _parse_customization(raw: object) -> MessageCustomization:
+def _parse_customization(raw: Any) -> MessageCustomization:
     if raw is None:
         return MessageCustomization()
-
     if not isinstance(raw, Mapping):
-        raise ValueError("Configuration field 'customization' must be a mapping if provided")
-
+        raise ValueError("Customization options must be provided as a mapping")
+    chips = _to_string_list(raw.get("chips") or raw.get("tags"))
     headers = _to_string_list(raw.get("header")) + _to_string_list(raw.get("headers"))
     footers = _to_string_list(raw.get("footer")) + _to_string_list(raw.get("footers"))
     replacements = _parse_replacements(raw.get("replace") or raw.get("replacements"))
-
     return MessageCustomization(
+        chips=tuple(chips),
         headers=tuple(headers),
         footers=tuple(footers),
         replacements=tuple(replacements.items()),
     )
 
 
-def _parse_replacements(raw: object) -> dict[str, str]:
+def _parse_formatting(raw: Any) -> FormattingProfile | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise ValueError("Formatting options must be provided as a mapping")
+
+    parse_mode = _optional_string(
+        raw.get("parse_mode") or raw.get("mode") or raw.get("parseMode")
+    )
+    disable_preview = raw.get("disable_preview")
+    if disable_preview is None:
+        disable_preview = raw.get("disable_link_preview")
+    max_length = raw.get("max_length") or raw.get("limit")
+    ellipsis = _optional_string(raw.get("ellipsis") or raw.get("truncate_suffix"))
+    attachments = _optional_string(
+        raw.get("attachments_style") or raw.get("attachments")
+    )
+
+    kwargs: dict[str, Any] = {}
+    if parse_mode is not None:
+        kwargs["parse_mode"] = parse_mode
+    if disable_preview is not None:
+        kwargs["disable_link_preview"] = bool(disable_preview)
+    if max_length is not None:
+        kwargs["max_length"] = int(max_length)
+    if ellipsis is not None:
+        kwargs["ellipsis"] = ellipsis
+    if attachments is not None:
+        normalised = attachments.lower()
+        if normalised not in {"compact", "minimal"}:
+            raise ValueError(
+                "Formatting attachments style must be either 'compact' or 'minimal'"
+            )
+        style_literal: Literal["compact", "minimal"] = cast(
+            Literal["compact", "minimal"], normalised
+        )
+        kwargs["attachments_style"] = style_literal
+
+    if not kwargs:
+        return None
+    provided = frozenset(kwargs.keys())
+    return FormattingProfile(**kwargs, provided=provided)
+
+
+def _validate_message_types(values: Sequence[str], label: str) -> tuple[str, ...]:
+    if not values:
+        return ()
+    cleaned: list[str] = []
+    invalid: list[str] = []
+    for value in values:
+        text = value.strip()
+        if not text:
+            continue
+        normalised = text.casefold()
+        if normalised not in _VALID_MESSAGE_TYPES:
+            invalid.append(value)
+            continue
+        cleaned.append(text)
+    if invalid:
+        expected = ", ".join(sorted(_VALID_MESSAGE_TYPES))
+        formatted = ", ".join(invalid)
+        raise ValueError(
+            f"Unsupported message type(s) in '{label}': {formatted}. "
+            f"Allowed values: {expected}"
+        )
+    return tuple(cleaned)
+
+
+def _parse_replacements(raw: Any) -> dict[str, str]:
     if raw is None:
         return {}
-
     replacements: dict[str, str] = {}
-
     if isinstance(raw, Mapping):
         for key, value in raw.items():
             if value is None:
                 continue
             replacements[str(key)] = str(value)
         return replacements
-
-    if isinstance(raw, list):
+    if isinstance(raw, Sequence) and not isinstance(raw, str):
         for item in raw:
             if not isinstance(item, Mapping):
                 continue
-            find_value = None
-            for candidate in ("find", "from", "search"):
-                if candidate in item:
-                    find_value = item[candidate]
-                    break
-            if find_value is None:
+            find = _optional_string(item.get("find") or item.get("from") or item.get("search"))
+            replace = _optional_string(item.get("replace") or item.get("to") or item.get("with"))
+            if find is None:
                 continue
-            replace_value = None
-            for candidate in ("replace", "to"):
-                if candidate in item:
-                    replace_value = item[candidate]
-                    break
-            if replace_value is None:
-                continue
-            replacements[str(find_value)] = str(replace_value)
+            replacements[find] = replace or ""
         return replacements
-
-    raise ValueError("Replacement rules must be provided as a mapping or a list of mappings")
-
-
-def _validate_message_types(values: Iterable[str], field_name: str) -> None:
-    invalid = [value for value in values if value.casefold() not in SUPPORTED_MESSAGE_TYPES]
-    if invalid:
-        supported = ", ".join(sorted(SUPPORTED_MESSAGE_TYPES))
-        raise ValueError(
-            "Configuration field "
-            f"'{field_name}' contains unsupported message types: {', '.join(invalid)}. "
-            f"Supported types: {supported}",
-        )
+    raise ValueError("Replacement rules must be a mapping or list of mappings")
 
 
-def _to_string_list(raw: object) -> list[str]:
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path}")
+    with path.open("r", encoding="utf-8") as file:
+        data = safe_load(file) or {}
+    if not isinstance(data, Mapping):
+        raise ValueError("Configuration file must contain a mapping at the top level")
+    return dict(data)
+
+
+def _expect_mapping(raw: Any, field: str, *, default: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
     if raw is None:
-        return []
-
-    if isinstance(raw, str):
-        value = raw.strip()
-        return [value] if value else []
-
-    if isinstance(raw, list):
-        items: list[str] = []
-        for entry in raw:
-            if entry is None:
-                continue
-            text = str(entry).strip()
-            if text:
-                items.append(text)
-        return items
-
-    raise ValueError("List configuration values must be strings or lists of strings")
+        return default or {}
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"Configuration field '{field}' must be a mapping")
+    return cast(Mapping[str, Any], raw)
 
 
-def _merge_sequences(first: Iterable[str], second: Iterable[str]) -> tuple[str, ...]:
-    return tuple(dict.fromkeys(str(item) for item in chain(first, second)))
+def _expect_sequence(raw: Any, field: str) -> Sequence[Any]:
+    if raw is None:
+        return ()
+    if isinstance(raw, Sequence) and not isinstance(raw, str):
+        return raw
+    raise ValueError(f"Configuration field '{field}' must be a sequence")
 
 
-def _casefold_unique(values: Iterable[object]) -> Iterator[str]:
-    seen: dict[str, None] = {}
-    for value in values:
-        if value is None:
-            continue
-        text = str(value).strip()
+def _require_string(raw: Mapping[str, Any], field: str, value: Any) -> str:
+    text = _optional_string(value)
+    if not text:
+        raise ValueError(f"Configuration field '{field}' must be a non-empty string")
+    return text
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_token_type(raw: Any) -> TokenType:
+    candidate = str(raw or "auto").strip().lower()
+    allowed: tuple[TokenType, ...] = ("auto", "bot", "user", "bearer")
+    if candidate not in allowed:
+        allowed_str = ", ".join(allowed)
+        raise ValueError(
+            f"Configuration field 'discord.token_type' must be one of: {allowed_str}"
+        )
+    return cast(TokenType, candidate)
+
+
+def _coerce_channel_id(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Configuration field '{field}' must contain integers for Discord channel IDs")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
         if not text:
-            continue
-        lowered = text.casefold()
-        if lowered in seen:
-            continue
-        seen[lowered] = None
-        yield lowered
+            raise ValueError(f"Configuration field '{field}' must contain integers for Discord channel IDs")
+        try:
+            return int(text)
+        except ValueError as exc:
+            raise ValueError(
+                f"Configuration field '{field}' must contain integers for Discord channel IDs"
+            ) from exc
+    raise ValueError(
+        f"Configuration field '{field}' must contain integers for Discord channel IDs"
+    )
 
 
-def _resolve_state_file(config_path: Path, raw_value: object, default: Path) -> Path:
+def _resolve_state_file(config_path: Path, raw_value: Any, default: Path) -> Path:
     candidate = Path(str(raw_value)).expanduser() if raw_value else default.expanduser()
     if not candidate.is_absolute():
         candidate = (config_path.parent / candidate).resolve()
@@ -568,3 +891,92 @@ def _freeze_replacements(values: Iterable[tuple[str, str]]) -> tuple[tuple[str, 
     for find, replace in values:
         frozen.append((str(find), str(replace)))
     return tuple(frozen)
+
+
+def _merge_sequences(first: Iterable[str], second: Iterable[str]) -> tuple[str, ...]:
+    result: dict[str, None] = {}
+    for item in list(first) + list(second):
+        if item is None:
+            continue
+        text = str(item).strip()
+        if not text:
+            continue
+        if text in result:
+            continue
+        result[text] = None
+    return tuple(result.keys())
+
+
+def _casefold_unique(values: Iterable[str]) -> Iterator[str]:
+    seen: dict[str, None] = {}
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        lowered = text.casefold()
+        if lowered in seen:
+            continue
+        seen[lowered] = None
+        yield lowered
+
+
+def _unique_non_empty(values: Iterable[str]) -> Iterator[str]:
+    seen: dict[str, None] = {}
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        if text in seen:
+            continue
+        seen[text] = None
+        yield text
+
+
+def _normalise_multiline(text: str) -> tuple[str, ...]:
+    lines = text.splitlines()
+    cleaned: list[str] = []
+    blank = False
+    for line in lines:
+        stripped = line.rstrip()
+        if stripped:
+            cleaned.append(stripped)
+            blank = False
+            continue
+        if not blank:
+            cleaned.append("")
+        blank = True
+    while cleaned and not cleaned[-1]:
+        cleaned.pop()
+    return tuple(cleaned)
+
+
+def _deduplicate(values: Sequence[str], *, fallback: tuple[str, ...]) -> tuple[str, ...]:
+    if not values:
+        return fallback
+    return tuple(dict.fromkeys(str(value).strip() for value in values if value and str(value).strip()))
+
+
+def _to_string_list(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        text = raw.strip()
+        return [text] if text else []
+    if isinstance(raw, Sequence):
+        items: list[str] = []
+        for value in raw:
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                items.append(text)
+        return items
+    raise ValueError("List configuration values must be strings or lists of strings")
+
+
+def _first_non_null(candidate: Any, default: Any) -> Any:
+    return candidate if candidate is not None else default

--- a/src/forward_monitor/networking.py
+++ b/src/forward_monitor/networking.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from collections import deque
+from typing import Iterable, Optional
+
+import aiohttp
+
+from .config import ProxyPoolSettings, RateLimitSettings, UserAgentSettings
+from .structured_logging import log_event
+
+__all__ = [
+    "ProxyPool",
+    "SoftRateLimiter",
+    "UserAgentProvider",
+]
+
+
+class SoftRateLimiter:
+    """Co-operative rate limiter with soft concurrency and jitter."""
+
+    __slots__ = (
+        "_settings",
+        "_semaphore",
+        "_lock",
+        "_next_slot",
+        "_recent",
+        "_cooldown_until",
+        "name",
+    )
+
+    def __init__(self, settings: RateLimitSettings, *, name: str) -> None:
+        self._settings = settings
+        self._semaphore = asyncio.Semaphore(max(1, settings.concurrency))
+        self._lock = asyncio.Lock()
+        self._next_slot = 0.0
+        self._recent: deque[float] = deque()
+        self._cooldown_until = 0.0
+        self.name = name
+
+    async def __aenter__(self) -> "SoftRateLimiter":
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.release()
+
+    async def acquire(self) -> None:
+        await self._semaphore.acquire()
+        loop = asyncio.get_running_loop()
+        jitter_min = max(0.0, self._settings.jitter_min_ms / 1000.0)
+        jitter_max = max(jitter_min, self._settings.jitter_max_ms / 1000.0)
+
+        while True:
+            async with self._lock:
+                now = loop.time()
+                waits: list[float] = []
+
+                if self._settings.per_second:
+                    waits.append(self._next_slot - now)
+
+                if self._settings.per_minute:
+                    cutoff = now - 60.0
+                    while self._recent and self._recent[0] < cutoff:
+                        self._recent.popleft()
+                    if len(self._recent) >= self._settings.per_minute:
+                        waits.append((self._recent[0] + 60.0) - now)
+
+                if self._cooldown_until > now:
+                    waits.append(self._cooldown_until - now)
+
+                wait_time = max(waits) if waits else 0.0
+                if wait_time <= 0:
+                    if self._settings.per_second:
+                        self._next_slot = now + 1.0 / self._settings.per_second
+                    if self._settings.per_minute:
+                        self._recent.append(now)
+                    break
+
+            await asyncio.sleep(wait_time)
+
+        if jitter_max > 0:
+            jitter = random.uniform(jitter_min, jitter_max)
+            if jitter > 0:
+                await asyncio.sleep(jitter)
+
+    def release(self) -> None:
+        self._semaphore.release()
+
+    async def impose_cooldown(self, seconds: float) -> None:
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            self._cooldown_until = max(self._cooldown_until, loop.time() + max(0.0, seconds))
+
+    @property
+    def settings(self) -> RateLimitSettings:
+        return self._settings
+
+
+class UserAgentProvider:
+    """Randomises user agent selection for outbound requests."""
+
+    __slots__ = ("_desktop", "_mobile", "_mobile_ratio", "_random")
+
+    def __init__(self, settings: UserAgentSettings) -> None:
+        desktop = list(settings.desktop)
+        mobile = list(settings.mobile)
+        if not desktop:
+            raise ValueError("Desktop user-agent pool cannot be empty")
+        if not mobile:
+            raise ValueError("Mobile user-agent pool cannot be empty")
+        self._desktop = desktop
+        self._mobile = mobile
+        self._mobile_ratio = min(max(float(settings.mobile_ratio), 0.0), 1.0)
+        self._random = random.Random()
+
+    def pick(self, *, prefer_mobile: Optional[bool] = None) -> str:
+        if prefer_mobile is None:
+            prefer_mobile = self._random.random() < self._mobile_ratio
+        pool = self._mobile if prefer_mobile else self._desktop
+        return self._random.choice(pool)
+
+
+class ProxyPool:
+    """Rotates proxies and performs health checks where configured."""
+
+    __slots__ = (
+        "_settings",
+        "_lock",
+        "_unhealthy",
+        "_verified",
+        "_name",
+        "_random",
+    )
+
+    def __init__(self, settings: ProxyPoolSettings, *, name: str) -> None:
+        self._settings = settings.normalised()
+        self._lock = asyncio.Lock()
+        self._unhealthy: dict[str, float] = {}
+        self._verified: set[str] = set()
+        self._name = name
+        self._random = random.Random()
+
+    def has_proxies(self) -> bool:
+        return bool(self._settings.endpoints)
+
+    async def get_proxy(self) -> str | None:
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            now = loop.time()
+            candidates = [
+                proxy
+                for proxy in self._settings.endpoints
+                if self._unhealthy.get(proxy, 0.0) <= now
+            ]
+            if not candidates:
+                return None
+            return self._random.choice(candidates)
+
+    async def ensure_healthy(
+        self, proxy: str | None, session: aiohttp.ClientSession
+    ) -> bool:
+        if proxy is None:
+            return True
+        if not self._settings.health_check_url:
+            return True
+        async with self._lock:
+            if proxy in self._verified and proxy not in self._unhealthy:
+                return True
+        url = self._settings.health_check_url
+        try:
+            async with session.get(
+                url,
+                proxy=proxy,
+                timeout=self._settings.health_check_timeout,
+            ) as response:
+                if response.status >= 400:
+                    raise aiohttp.ClientError(f"status={response.status}")
+        except Exception as exc:  # pragma: no cover - network failure paths
+            await self.mark_bad(proxy, reason=f"health_check_failed:{exc}")
+            return False
+        async with self._lock:
+            self._verified.add(proxy)
+        log_event(
+            "proxy_checked",
+            level=20,
+            discord_channel_id=None,
+            discord_message_id=None,
+            telegram_chat_id=None,
+            attempt=None,
+            outcome="healthy",
+            latency_ms=None,
+            extra={"service": self._name, "proxy": proxy},
+        )
+        return True
+
+    async def mark_bad(self, proxy: str, *, reason: str) -> None:
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            self._unhealthy[proxy] = loop.time() + self._settings.recovery_seconds
+            self._verified.discard(proxy)
+        log_event(
+            "proxy_marked_unhealthy",
+            level=30,
+            discord_channel_id=None,
+            discord_message_id=None,
+            telegram_chat_id=None,
+            attempt=None,
+            outcome="cooldown",
+            latency_ms=None,
+            extra={"service": self._name, "proxy": proxy, "reason": reason},
+        )
+
+    async def mark_success(self, proxy: str | None) -> None:
+        if proxy is None:
+            return
+        async with self._lock:
+            self._unhealthy.pop(proxy, None)
+            self._verified.add(proxy)
+
+    def endpoints(self) -> Iterable[str]:
+        return tuple(self._settings.endpoints)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,15 +1,40 @@
-from __future__ import annotations
-
 import textwrap
 from pathlib import Path
+from typing import Any, Mapping
 
 import pytest
+from yaml import safe_dump, safe_load
 
 from forward_monitor.config import MonitorConfig
 
 
-def _write_config(path: Path, content: str) -> None:
-    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+def _write_config(path: Path, content: str | Mapping[str, Any]) -> None:
+    if isinstance(content, str):
+        text = textwrap.dedent(content).strip() + "\n"
+        path.write_text(text, encoding="utf-8")
+        return
+    rendered = safe_dump(content, sort_keys=False).rstrip() + "\n"
+    path.write_text(rendered, encoding="utf-8")
+
+
+def _base_config(extra: str = "") -> str:
+    base = textwrap.dedent(
+        """
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
+        """
+    ).strip()
+    extra_text = textwrap.dedent(extra).strip()
+    if extra_text:
+        return f"{base}\n{extra_text}\n"
+    return base + "\n"
 
 
 def test_state_file_relative_to_config(tmp_path: Path) -> None:
@@ -19,64 +44,72 @@ def test_state_file_relative_to_config(tmp_path: Path) -> None:
 
     _write_config(
         config_path,
-        """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        state_file: state/monitor.json
-        """,
+        _base_config(
+            """
+            runtime:
+              state_file: state/monitor.json
+            """
+        ),
     )
 
     config = MonitorConfig.from_file(config_path)
-
     expected = config_dir / "state" / "monitor.json"
-    assert config.state_file == expected
+    assert config.runtime.state_file == expected
 
 
 def test_default_state_file_uses_config_directory(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
-    _write_config(
-        config_path,
-        """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        """,
-    )
+    _write_config(config_path, _base_config())
 
     config = MonitorConfig.from_file(config_path)
-
-    assert config.state_file == tmp_path / "monitor_state.json"
+    assert config.runtime.state_file == tmp_path / "monitor_state.json"
 
 
 def test_discord_token_type_defaults_to_auto(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
+    _write_config(config_path, _base_config())
 
+    config = MonitorConfig.from_file(config_path)
+    assert config.discord.token_type == "auto"
+
+
+def test_discord_token_type_normalized(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+          token_type: BOT
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
         """,
     )
 
     config = MonitorConfig.from_file(config_path)
+    assert config.discord.token_type == "bot"
 
-    assert config.discord_token_type == "auto"
 
-
-def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
+def test_discord_token_type_invalid_rejected(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        poll_interval: -5
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+          token_type: something
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
         """,
     )
 
@@ -84,17 +117,16 @@ def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
         MonitorConfig.from_file(config_path)
 
 
-def test_discord_token_type_invalid_rejected(tmp_path: Path) -> None:
+def test_negative_poll_interval_rejected(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
-        """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        discord_token_type: something
-        """,
+        _base_config(
+            """
+            runtime:
+              poll_every: -5
+            """
+        ),
     )
 
     with pytest.raises(ValueError):
@@ -103,66 +135,61 @@ def test_discord_token_type_invalid_rejected(tmp_path: Path) -> None:
 
 def test_zero_poll_interval_allowed(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
-        """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        poll_interval: 0
-        """,
+        _base_config(
+            """
+            runtime:
+              poll_every: 0
+            """
+        ),
     )
 
     config = MonitorConfig.from_file(config_path)
-
-    assert config.poll_interval == 0
-
-
-def test_discord_token_type_normalized(tmp_path: Path) -> None:
-    config_path = tmp_path / "forward.yml"
-
-    _write_config(
-        config_path,
-        """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        discord_token_type: BOT
-        """,
-    )
-
-    config = MonitorConfig.from_file(config_path)
-
-    assert config.discord_token_type == "bot"
+    assert config.runtime.poll_interval == 0
 
 
 @pytest.mark.parametrize(
-    "field, value",
+    "content",
     [
-        ("discord_token", ""),
-        ("discord_token", "   "),
-        ("telegram_token", ""),
-        ("telegram_token", "   "),
-        ("telegram_chat_id", ""),
-        ("telegram_chat_id", "   "),
+        """
+        telegram:
+          token: ""
+          chat: "@chat"
+        discord:
+          token: discord
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
+        """,
+        """
+        telegram:
+          token: telegram
+          chat: ""
+        discord:
+          token: discord
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
+        """,
+        """
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: ""
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
+        """,
     ],
 )
-def test_required_tokens_cannot_be_empty(tmp_path: Path, field: str, value: str) -> None:
+def test_required_tokens_cannot_be_empty(tmp_path: Path, content: str) -> None:
     config_path = tmp_path / "forward.yml"
-
-    discord_value = value if field == "discord_token" else "discord"
-    telegram_value = value if field == "telegram_token" else "telegram"
-    chat_value = value if field == "telegram_chat_id" else "@chat"
-
-    _write_config(
-        config_path,
-        f"""
-        discord_token: "{discord_value}"
-        telegram_token: "{telegram_value}"
-        telegram_chat_id: "{chat_value}"
-        """,
-    )
+    _write_config(config_path, content)
 
     with pytest.raises(ValueError):
         MonitorConfig.from_file(config_path)
@@ -170,38 +197,47 @@ def test_required_tokens_cannot_be_empty(tmp_path: Path, field: str, value: str)
 
 def test_customization_replacements_allow_empty_strings(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        customization:
-          replacements:
-            - find: "Secret"
-              replace: ""
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+        forward:
+          defaults:
+            text:
+              replacements:
+                - find: Secret
+                  replace: ""
+          channels:
+            - discord: 1
+              telegram: "-100"
         """,
     )
 
     config = MonitorConfig.from_file(config_path)
-    prepared = config.customization.prepare()
+    prepared = config.defaults.customization.prepare()
     assert prepared.replacements == (("Secret", ""),)
-    assert prepared.apply("Secret") == ""
+    rendered = prepared.render("Secret")
+    assert rendered.body_lines == ()
 
 
 def test_channel_mapping_requires_non_empty_chat(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        announcement_channels:
-          - discord_channel_id: 1
-            telegram_chat_id: "   "
+        telegram:
+          token: telegram
+          chat: ""
+        discord:
+          token: discord
+        forward:
+          channels:
+            - discord: 1
+              telegram: "   "
         """,
     )
 
@@ -211,37 +247,77 @@ def test_channel_mapping_requires_non_empty_chat(tmp_path: Path) -> None:
 
 def test_channel_mapping_captures_display_name(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        announcement_channels:
-          - discord_channel_id: 1
-            telegram_chat_id: "@chat"
-            display_name: "Announcements"
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+        forward:
+          channels:
+            - discord: 1
+              telegram: "-100"
+              name: Announcements
         """,
     )
 
     config = MonitorConfig.from_file(config_path)
-    assert config.announcement_channels[0].display_name == "Announcements"
+    assert config.channels[0].display_name == "Announcements"
 
 
 def test_invalid_message_type_rejected(tmp_path: Path) -> None:
     config_path = tmp_path / "forward.yml"
-
     _write_config(
         config_path,
         """
-        discord_token: discord
-        telegram_token: telegram
-        telegram_chat_id: "@chat"
-        filters:
-          allowed_types: [text, unknown]
+        telegram:
+          token: telegram
+          chat: "@chat"
+        discord:
+          token: discord
+        forward:
+          defaults:
+            filters:
+              allowed_types: [text, unknown]
+          channels:
+            - discord: 1
+              telegram: "-100"
         """,
     )
 
     with pytest.raises(ValueError):
         MonitorConfig.from_file(config_path)
+
+
+def test_formatting_defaults_merge(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+    _write_config(
+        config_path,
+        """
+        telegram:
+          token: telegram
+          chat: "@chat"
+          formatting:
+            parse_mode: MarkdownV2
+            disable_preview: false
+        discord:
+          token: discord
+        forward:
+          defaults:
+            formatting:
+              attachments: compact
+          channels:
+            - discord: 1
+              telegram: "-100"
+              formatting:
+                attachments: minimal
+        """,
+    )
+
+    config = MonitorConfig.from_file(config_path)
+    channel_formatting = config.channels[0].formatting
+    assert channel_formatting.parse_mode == "MarkdownV2"
+    assert channel_formatting.disable_link_preview is False
+    assert channel_formatting.attachments_style == "minimal"

--- a/tests/test_monitor_filters.py
+++ b/tests/test_monitor_filters.py
@@ -5,7 +5,12 @@ from typing import cast
 
 import pytest
 
-from forward_monitor.config import ChannelMapping, MessageCustomization, MessageFilters
+from forward_monitor.config import (
+    ChannelMapping,
+    FormattingProfile,
+    MessageCustomization,
+    MessageFilters,
+)
 from forward_monitor.formatter import (
     AttachmentInfo,
     FormattedMessage,
@@ -213,6 +218,7 @@ async def test_forward_message_logs_filter_reason(caplog: pytest.LogCaptureFixtu
         mapping=ChannelMapping(discord_channel_id=10, telegram_chat_id="chat"),
         filters=MessageFilters(blacklist=("deny",)).prepare(),
         customization=MessageCustomization().prepare(),
+        formatting=FormattingProfile(),
     )
 
     message = cast(
@@ -224,20 +230,53 @@ async def test_forward_message_logs_filter_reason(caplog: pytest.LogCaptureFixtu
         def __init__(self) -> None:
             self.sent: list[tuple[str, str]] = []
 
-        async def send_message(self, chat_id: str, text: str) -> None:
+        async def send_message(
+            self,
+            chat_id: str,
+            text: str,
+            *,
+            parse_mode: str | None = None,
+            disable_web_page_preview: bool | None = None,
+        ) -> None:
             self.sent.append((chat_id, text))
 
-        async def send_photo(self, chat_id: str, photo: str, *, caption: str | None = None) -> None:
+        async def send_photo(
+            self,
+            chat_id: str,
+            photo: str,
+            *,
+            caption: str | None = None,
+            parse_mode: str | None = None,
+        ) -> None:
             raise AssertionError("send_photo should not be called")
 
-        async def send_video(self, chat_id: str, video: str, *, caption: str | None = None) -> None:
+        async def send_video(
+            self,
+            chat_id: str,
+            video: str,
+            *,
+            caption: str | None = None,
+            parse_mode: str | None = None,
+        ) -> None:
             raise AssertionError("send_video should not be called")
 
-        async def send_audio(self, chat_id: str, audio: str, *, caption: str | None = None) -> None:
+        async def send_audio(
+            self,
+            chat_id: str,
+            audio: str,
+            *,
+            caption: str | None = None,
+            parse_mode: str | None = None,
+        ) -> None:
             raise AssertionError("send_audio should not be called")
 
         async def send_document(
-            self, chat_id: str, document: str, *, caption: str | None = None
+            self,
+            chat_id: str,
+            document: str,
+            *,
+            caption: str | None = None,
+            parse_mode: str | None = None,
         ) -> None:
             raise AssertionError("send_document should not be called")
 


### PR DESCRIPTION
## Summary
- add explicit override tracking for formatting profiles and validate allowed/blocked message types
- introduce SoftRateLimiter, ProxyPool, and UserAgentProvider networking helpers and require them in the Discord/Telegram clients
- refresh the sample configuration and update unit tests to cover the new configuration schema and client behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d2c6f10ae0832ba3158d9bc71a9880