### PR TITLE
perf(async): bound Discord fetches and streamline formatter

### DIFF
--- a/src/forward_monitor/discord_client.py
+++ b/src/forward_monitor/discord_client.py
@@ -5,7 +5,7 @@ import logging
 import random
 from collections.abc import Mapping
 from time import perf_counter
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import aiohttp
 
@@ -124,7 +124,7 @@ class DiscordClient:
         self,
         channel_id: int,
         *,
-        after: Optional[str] = None,
+        after: str | None = None,
         limit: int = 100,
     ) -> list[DiscordMessage]:
         params: dict[str, str] = {"limit": str(max(1, min(limit, 100)))}
@@ -147,7 +147,7 @@ class DiscordClient:
         method: str,
         url: str,
         *,
-        params: Optional[Mapping[str, str]] = None,
+        params: Mapping[str, str] | None = None,
         max_rate_limit_retries: int = _RATE_LIMIT_MAX_RETRIES,
         max_network_retries: int = _NETWORK_MAX_RETRIES,
         discord_channel_id: int | None = None,

--- a/src/forward_monitor/networking.py
+++ b/src/forward_monitor/networking.py
@@ -4,7 +4,7 @@ import asyncio
 import random
 from collections import deque
 from types import TracebackType
-from typing import Iterable, Optional
+from typing import Iterable
 
 import aiohttp
 
@@ -121,7 +121,7 @@ class UserAgentProvider:
         self._mobile_ratio = min(max(float(settings.mobile_ratio), 0.0), 1.0)
         self._random = random.Random()
 
-    def pick(self, *, prefer_mobile: Optional[bool] = None) -> str:
+    def pick(self, *, prefer_mobile: bool | None = None) -> str:
         if prefer_mobile is None:
             prefer_mobile = self._random.random() < self._mobile_ratio
         pool = self._mobile if prefer_mobile else self._desktop
@@ -185,7 +185,8 @@ class ProxyPool:
             ) as response:
                 if response.status >= 400:
                     raise aiohttp.ClientError(f"status={response.status}")
-        except Exception as exc:  # pragma: no cover - network failure paths
+        # pragma: no cover - network failure paths exercised via integration tests.
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             await self.mark_bad(proxy, reason=f"health_check_failed:{exc}")
             return False
         async with self._lock:

--- a/src/forward_monitor/telegram_client.py
+++ b/src/forward_monitor/telegram_client.py
@@ -6,7 +6,7 @@ import random
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Any, Dict, Set
+from typing import Any
 
 import aiohttp
 
@@ -63,7 +63,7 @@ class TelegramClient:
         parse_mode: str | None = None,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         disable_preview = (
             self._default_disable_preview
             if disable_web_page_preview is None
@@ -93,7 +93,7 @@ class TelegramClient:
         parse_mode: str | None = None,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return await self._send_media(
             method="sendPhoto",
             chat_id=chat_id,
@@ -114,7 +114,7 @@ class TelegramClient:
         parse_mode: str | None = None,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return await self._send_media(
             method="sendVideo",
             chat_id=chat_id,
@@ -135,7 +135,7 @@ class TelegramClient:
         parse_mode: str | None = None,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return await self._send_media(
             method="sendAudio",
             chat_id=chat_id,
@@ -156,7 +156,7 @@ class TelegramClient:
         parse_mode: str | None = None,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return await self._send_media(
             method="sendDocument",
             chat_id=chat_id,
@@ -179,8 +179,8 @@ class TelegramClient:
         parse_mode: str | None,
         retry_attempts: int,
         retry_statuses: Iterable[int] | None,
-    ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {"chat_id": chat_id, media_field: media_value}
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"chat_id": chat_id, media_field: media_value}
         if caption is not None:
             payload["caption"] = caption
         if parse_mode or self._default_parse_mode:
@@ -195,11 +195,11 @@ class TelegramClient:
     async def _post(
         self,
         method: str,
-        payload: Dict[str, Any],
+        payload: dict[str, Any],
         *,
         retry_attempts: int = 5,
         retry_statuses: Iterable[int] | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         url = f"https://api.telegram.org/bot{self._token}/{method}"
         statuses = (
             self.RETRYABLE_STATUSES
@@ -331,8 +331,8 @@ class TelegramClient:
                 raise RuntimeError("Telegram API request failed due to a network error") from exc
 
 
-def _normalise_retry_statuses(statuses: Iterable[int | str]) -> Set[int]:
-    normalised: Set[int] = set()
+def _normalise_retry_statuses(statuses: Iterable[int | str]) -> set[int]:
+    normalised: set[int] = set()
     for status in statuses:
         try:
             normalised.add(int(status))

--- a/tests/test_monitor_forwarding.py
+++ b/tests/test_monitor_forwarding.py
@@ -246,6 +246,7 @@ async def test_sync_announcements_fetches_multiple_batches() -> None:
     discord = FakeDiscord([first_batch, second_batch])
     telegram = StubTelegram()
     state = DummyState()
+    api_semaphore = asyncio.Semaphore(8)
 
     fetched, forwarded_count = await _sync_announcements(
         [context],
@@ -254,6 +255,7 @@ async def test_sync_announcements_fetches_multiple_batches() -> None:
         state,
         min_delay=0,
         max_delay=0,
+        api_semaphore=api_semaphore,
     )
 
     # 102 messages should have been forwarded once.
@@ -323,6 +325,7 @@ async def test_sync_announcements_fetches_channels_in_parallel() -> None:
     discord = ParallelDiscord()
     telegram = StubTelegram()
     state = DummyState()
+    api_semaphore = asyncio.Semaphore(8)
 
     sync_task = asyncio.create_task(
         _sync_announcements(
@@ -332,6 +335,7 @@ async def test_sync_announcements_fetches_channels_in_parallel() -> None:
             state,
             min_delay=0,
             max_delay=0,
+            api_semaphore=api_semaphore,
         )
     )
 
@@ -395,6 +399,7 @@ async def test_sync_announcements_skips_failed_message(
 
     telegram = StubTelegram()
     state = DummyState()
+    api_semaphore = asyncio.Semaphore(8)
 
     fetched, forwarded_count = await _sync_announcements(
         [context],
@@ -403,6 +408,7 @@ async def test_sync_announcements_skips_failed_message(
         state,
         min_delay=0,
         max_delay=0,
+        api_semaphore=api_semaphore,
     )
 
     assert forwarded == ["second"]
@@ -442,6 +448,7 @@ async def test_sync_announcements_counts_only_forwarded_messages() -> None:
 
     telegram = StubTelegram()
     state = DummyState()
+    api_semaphore = asyncio.Semaphore(8)
 
     fetched, forwarded_count = await _sync_announcements(
         [context],
@@ -450,6 +457,7 @@ async def test_sync_announcements_counts_only_forwarded_messages() -> None:
         state,
         min_delay=0,
         max_delay=0,
+        api_semaphore=api_semaphore,
     )
 
     assert fetched == 2

--- a/tests/test_monitor_run.py
+++ b/tests/test_monitor_run.py
@@ -96,6 +96,7 @@ async def test_run_monitor_propagates_cancellation(
         state: monitor.MonitorState,
         min_delay: float,
         max_delay: float,
+        api_semaphore: asyncio.Semaphore,
     ) -> None:
         state.update_last_message_id(123, "456")
         raise asyncio.CancelledError


### PR DESCRIPTION
## Summary
- modernize typing usage and tighten proxy health check handling
- bound Discord fetch concurrency with a shared semaphore, route monitor logs through the bridge logger, and update tests
- optimize formatter chunking to avoid repeated slicing and expose a safe cut constant

## Testing
- make ci
- PYTHONPATH=src python -m scripts.bench --iterations 5 --length 4000 --attachments 4

------
https://chatgpt.com/codex/tasks/task_b_68d2e4d95bfc832ba1e72cd0e1278ef6