### PR TITLE
perf(core): streamline fetch aggregation and logging

### DIFF
--- a/scripts/profile.py
+++ b/scripts/profile.py
@@ -1,36 +1,97 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
-import cProfile
+import asyncio
+import importlib.util
+import pstats
+import sys
+import sysconfig
 from pathlib import Path
 
-from scripts.bench import benchmark_formatter, benchmark_processing
+STDLIB_PROFILE = Path(sysconfig.get_path("stdlib")) / "profile.py"
+if STDLIB_PROFILE.exists():
+    spec = importlib.util.spec_from_file_location("_stdlib_profile", STDLIB_PROFILE)
+    if spec and spec.loader:
+        std_profile = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(std_profile)
+        sys.modules.setdefault("profile", std_profile)
+
+import cProfile  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_PATH = ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.append(str(SRC_PATH))
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from scripts.bench import benchmark_formatter, benchmark_forwarding  # noqa: E402
+
+PROFILES_DIR = Path("profiles")
+
+
+def profile_formatter(iterations: int, output: Path) -> None:
+    profiler = cProfile.Profile()
+    profiler.enable()
+    benchmark_formatter(iterations)
+    profiler.disable()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    profiler.dump_stats(str(output))
+    stats = pstats.Stats(profiler)
+    stats.sort_stats("cumulative").print_stats(20)
+
+
+def profile_forwarding(iterations: int, output: Path) -> None:
+    profiler = cProfile.Profile()
+
+    async def runner() -> None:
+        profiler.enable()
+        await benchmark_forwarding(iterations)
+        profiler.disable()
+
+    asyncio.run(runner())
+    output.parent.mkdir(parents=True, exist_ok=True)
+    profiler.dump_stats(str(output))
+    stats = pstats.Stats(profiler)
+    stats.sort_stats("cumulative").print_stats(20)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate CPU profiles for hot paths",
+    )
+    parser.add_argument(
+        "--format-count",
+        type=int,
+        default=1000,
+        help="Iterations for formatter benchmark",
+    )
+    parser.add_argument(
+        "--forward-count",
+        type=int,
+        default=300,
+        help="Iterations for forwarding benchmark",
+    )
+    parser.add_argument(
+        "--formatter-output",
+        type=Path,
+        default=PROFILES_DIR / "formatter.prof",
+        help="Profile output path for formatter",
+    )
+    parser.add_argument(
+        "--forward-output",
+        type=Path,
+        default=PROFILES_DIR / "forwarding.prof",
+        help="Profile output path for forwarding",
+    )
+    return parser.parse_args()
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Profile benchmark scenarios.")
-    parser.add_argument(
-        "target",
-        choices=("formatter", "processing"),
-        help="Benchmark target to profile",
-    )
-    parser.add_argument("--iterations", type=int, default=500, help="Iterations to run")
-    args = parser.parse_args()
-
-    profiles_dir = Path("profiles")
-    profiles_dir.mkdir(parents=True, exist_ok=True)
-    profile_path = profiles_dir / f"{args.target}.prof"
-
-    if args.target == "formatter":
-        runner = benchmark_formatter
-    else:
-        runner = benchmark_processing
-
-    def run() -> None:
-        runner(args.iterations)
-
-    cProfile.runctx("run()", globals(), locals(), str(profile_path))
-    print(f"Profile written to {profile_path}")
+    args = parse_args()
+    profile_formatter(args.format_count, args.formatter_output)
+    profile_forwarding(args.forward_count, args.forward_output)
 
 
 if __name__ == "__main__":

--- a/src/forward_monitor/formatter.py
+++ b/src/forward_monitor/formatter.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import html
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence, cast
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from .config import CustomisedText, FormattingProfile
@@ -150,7 +151,7 @@ def _attachment_from_payload(
 
     filename_text = str(filename) if filename else None
     content_type_text = str(content_type) if content_type else None
-    if isinstance(size, (int, float)):
+    if isinstance(size, int | float):
         size_value = int(size)
     elif isinstance(size, str):
         try:
@@ -499,12 +500,14 @@ def _attachment_summary(
     if not attachments:
         return None
     domains: list[str] = []
+    seen_domains: set[str] = set()
     for attachment in attachments:
         domain = attachment.domain or attachment.url
         if not domain:
             continue
-        cleaned = domain.split("/", 1)[0]
-        if cleaned not in domains:
+        cleaned, _, _ = domain.partition("/")
+        if cleaned and cleaned not in seen_domains:
+            seen_domains.add(cleaned)
             domains.append(cleaned)
 
     summary = ""

--- a/src/forward_monitor/networking.py
+++ b/src/forward_monitor/networking.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import random
 from collections import deque
+from collections.abc import Iterable
 from types import TracebackType
-from typing import Iterable
 
 import aiohttp
 
@@ -40,7 +40,7 @@ class SoftRateLimiter:
         self._cooldown_until = 0.0
         self.name = name
 
-    async def __aenter__(self) -> "SoftRateLimiter":
+    async def __aenter__(self) -> SoftRateLimiter:
         await self.acquire()
         return self
 
@@ -197,7 +197,7 @@ class ProxyPool:
                 if response.status >= 400:
                     raise aiohttp.ClientError(f"status={response.status}")
         # pragma: no cover - network failure paths exercised via integration tests.
-        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+        except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
             await self.mark_bad(
                 proxy,
                 reason=f"health_check_failed:{exc}",
@@ -280,7 +280,7 @@ class ProxyPool:
                 ) as response:
                     if response.status >= 400:
                         raise aiohttp.ClientError(f"status={response.status}")
-            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
                 log_event(
                     "proxy_rotation",
                     level=30,

--- a/src/forward_monitor/structured_logging.py
+++ b/src/forward_monitor/structured_logging.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Final, Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Final
 
 BRIDGE_LOGGER_NAME: Final = "bridge"
 _REDACT_KEYS: Final = {"token", "authorization"}
 _MAX_STRING_LENGTH: Final = 512
+_LOGGER = logging.getLogger(BRIDGE_LOGGER_NAME)
 
 
 def configure_bridge_logging(level: int) -> None:
-    logger = logging.getLogger(BRIDGE_LOGGER_NAME)
+    logger = _LOGGER
     if logger.handlers:
         return
     handler = logging.StreamHandler()
@@ -53,8 +55,7 @@ def log_event(
                 continue
             payload[key_text] = _sanitize_value(value)
 
-    logger = logging.getLogger(BRIDGE_LOGGER_NAME)
-    logger.log(level, json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    _LOGGER.log(level, json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
 
 
 def _sanitize_value(value: Any) -> Any:
@@ -62,6 +63,6 @@ def _sanitize_value(value: Any) -> Any:
         if len(value) > _MAX_STRING_LENGTH:
             return f"{value[:_MAX_STRING_LENGTH]}…"
         return value
-    if isinstance(value, (int, float, bool)) or value is None:
+    if isinstance(value, bool | int | float) or value is None:
         return value
     return str(value)

--- a/src/forward_monitor/types.py
+++ b/src/forward_monitor/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 class DiscordUser(TypedDict, total=False):
@@ -72,3 +72,28 @@ class DiscordMessage(TypedDict, total=False):
     embeds: list[DiscordEmbed]
     mentions: list[DiscordUser]
     mention_channels: list[DiscordChannelMention]
+
+
+class TelegramAPIPayload(TypedDict, total=False):
+    chat_id: str
+    text: str
+    disable_web_page_preview: bool
+    parse_mode: str
+    photo: str
+    video: str
+    audio: str
+    document: str
+    caption: str
+
+
+class TelegramResponseParameters(TypedDict, total=False):
+    retry_after: float
+
+
+class TelegramAPIResponse(TypedDict, total=False):
+    ok: bool
+    result: Any
+    description: str
+    error_code: int
+    parameters: TelegramResponseParameters
+    retry_after: float

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,6 +149,46 @@ def test_zero_poll_interval_allowed(tmp_path: Path) -> None:
     assert config.runtime.poll_interval == 0
 
 
+def test_runtime_caps_parsed(tmp_path: Path) -> None:
+    config_path = tmp_path / "forward.yml"
+    _write_config(
+        config_path,
+        _base_config(
+            """
+            runtime:
+              max_messages: 250
+              max_fetch_seconds: 12.5
+            """
+        ),
+    )
+
+    config = MonitorConfig.from_file(config_path)
+    assert config.runtime.max_messages_per_channel == 250
+    assert config.runtime.max_fetch_seconds == pytest.approx(12.5)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [("max_messages", 0), ("max_fetch_seconds", 0)],
+)
+def test_runtime_caps_must_be_positive(
+    tmp_path: Path, field: str, value: int
+) -> None:
+    config_path = tmp_path / "forward.yml"
+    _write_config(
+        config_path,
+        _base_config(
+            f"""
+            runtime:
+              {field}: {value}
+            """
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        MonitorConfig.from_file(config_path)
+
+
 @pytest.mark.parametrize(
     "content",
     [

--- a/tests/test_monitor_forwarding.py
+++ b/tests/test_monitor_forwarding.py
@@ -6,6 +6,8 @@ from typing import Any, Mapping, Sequence, cast
 import pytest
 
 from forward_monitor.config import (
+    DEFAULT_MAX_FETCH_SECONDS,
+    DEFAULT_MAX_MESSAGES_PER_CHANNEL,
     ChannelMapping,
     CustomisedText,
     FormattingProfile,
@@ -255,6 +257,8 @@ async def test_sync_announcements_fetches_multiple_batches() -> None:
         state,
         min_delay=0,
         max_delay=0,
+        max_messages=DEFAULT_MAX_MESSAGES_PER_CHANNEL,
+        max_fetch_seconds=DEFAULT_MAX_FETCH_SECONDS,
         api_semaphore=api_semaphore,
     )
 
@@ -335,6 +339,8 @@ async def test_sync_announcements_fetches_channels_in_parallel() -> None:
             state,
             min_delay=0,
             max_delay=0,
+            max_messages=DEFAULT_MAX_MESSAGES_PER_CHANNEL,
+            max_fetch_seconds=DEFAULT_MAX_FETCH_SECONDS,
             api_semaphore=api_semaphore,
         )
     )
@@ -408,6 +414,8 @@ async def test_sync_announcements_skips_failed_message(
         state,
         min_delay=0,
         max_delay=0,
+        max_messages=DEFAULT_MAX_MESSAGES_PER_CHANNEL,
+        max_fetch_seconds=DEFAULT_MAX_FETCH_SECONDS,
         api_semaphore=api_semaphore,
     )
 
@@ -457,6 +465,8 @@ async def test_sync_announcements_counts_only_forwarded_messages() -> None:
         state,
         min_delay=0,
         max_delay=0,
+        max_messages=DEFAULT_MAX_MESSAGES_PER_CHANNEL,
+        max_fetch_seconds=DEFAULT_MAX_FETCH_SECONDS,
         api_semaphore=api_semaphore,
     )
 

--- a/tests/test_monitor_run.py
+++ b/tests/test_monitor_run.py
@@ -96,6 +96,8 @@ async def test_run_monitor_propagates_cancellation(
         state: monitor.MonitorState,
         min_delay: float,
         max_delay: float,
+        max_messages: int,
+        max_fetch_seconds: float,
         api_semaphore: asyncio.Semaphore,
     ) -> None:
         state.update_last_message_id(123, "456")


### PR DESCRIPTION
**Summary**

* Completed a runtime refactor that adds bounded fetch controls and benchmarking toolchains. New defaults for per-iteration fetch limits and maximum fetch duration live in `src/forward_monitor/config.py`, and are parsed via `_parse_runtime` before being passed through `run_monitor` into the `monitor._sync_announcements` loop so message fetching is capped. Telegram client payload handling is now strongly typed, reusing a single request payload while safely casting the API response. Discord retry logic now honors `Retry-After` headers and HTTP dates before falling back to JSON metadata. Attachment filtering retains its previous behavior thanks to a helper that recovers domains even when the precomputed value is absent. Synchronous bench and profile scripts were introduced to exercise formatter and forwarding hot paths with synthetic payloads, writing reports to `profiles/`. All unit tests pass (`make ci`).
* Streamlined announcement syncing and logging: `_sync_announcements` now stores fetch results by channel to maintain ordering without keeping task handles, attachment summaries dedupe domains in O(n), and structured logging reuses a single cached logger while Telegram rate-limit telemetry reuses the cached chat id.

**Outstandings / Next steps**

* No open TODOs remain in the codebase.
* Testing matrix is solid (full `make ci`), but consider heavier integration runs once further performance tuning happens.
* No known bugs or quirks pending.


------
https://chatgpt.com/codex/tasks/task_b_68d2f5e64e04832ba63d55edcae7e934