### PR TITLE
Add layered configuration overrides and regression tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,6 +21,8 @@ def test_main_reports_missing_config(
             config=str(missing_path),
             once=True,
             log_level="INFO",
+            profile=[],
+            overrides=[],
         )
 
     monkeypatch.setattr(cli, "parse_args", fake_parse_args)
@@ -31,3 +33,28 @@ def test_main_reports_missing_config(
 
     assert exc.value.code == 1
     assert str(missing_path) in caplog.text
+
+
+def test_main_rejects_invalid_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text("telegram:\n  token: t\n  chat: c\ndiscord:\n  token: d\nforward:\n  channels:\n    - discord: 1\n      telegram: c\n", encoding="utf-8")
+
+    def fake_parse_args() -> argparse.Namespace:
+        return argparse.Namespace(
+            config=str(config_path),
+            once=True,
+            log_level="INFO",
+            profile=[],
+            overrides=["runtime.poll_every"],
+        )
+
+    monkeypatch.setattr(cli, "parse_args", fake_parse_args)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+    assert exc.value.code == 1
+    assert "Invalid override" in caplog.text


### PR DESCRIPTION
## Summary
- add layered configuration loading that merges profiles, environment variables and CLI overrides with explicit priority
- extend the CLI to accept `--profile` and `--override` flags and validate override expressions before startup
- cover profile/env/CLI precedence and error handling with new regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d30cbf08b0832b916f3b68c976ebe6