### PR TITLE
Handle startup runtime errors gracefully

### DIFF
--- a/src/forward_monitor/__main__.py
+++ b/src/forward_monitor/__main__.py
@@ -56,6 +56,20 @@ def main() -> None:
             extra={"reason": str(exc)},
         )
         sys.exit(1)
+    except RuntimeError as exc:
+        logging.getLogger(__name__).error("Monitor terminated: %s", exc)
+        log_event(
+            "startup_failed",
+            level=logging.ERROR,
+            discord_channel_id=None,
+            discord_message_id=None,
+            telegram_chat_id=None,
+            attempt=1,
+            outcome="failure",
+            latency_ms=None,
+            extra={"reason": str(exc)},
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- catch startup runtime errors raised by the monitor to avoid uncaught tracebacks
- log a concise termination message and emit the existing startup_failed event before exiting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d32962c948832b96d6ead28b0dd0a5