### PR TITLE
Gracefully handle keyboard interrupts

### DIFF
--- a/src/forward_monitor/__main__.py
+++ b/src/forward_monitor/__main__.py
@@ -42,6 +42,9 @@ def main() -> None:
     try:
         config = MonitorConfig.from_file(config_path)
         asyncio.run(run_monitor(config, once=args.once))
+    except KeyboardInterrupt:
+        logging.getLogger(__name__).info("Monitor interrupted by user")
+        sys.exit(0)
     except (FileNotFoundError, ValueError, OSError) as exc:
         logging.getLogger(__name__).error("Failed to start monitor: %s", exc)
         log_event(


### PR DESCRIPTION
## Summary
- exit cleanly when the monitor is interrupted with Ctrl+C to avoid a traceback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d32d6e1e3c832b89009cf2dad376bd