### PR TITLE
Fix typing expectations for monitor tests

### DIFF
--- a/tests/test_monitor_forwarding.py
+++ b/tests/test_monitor_forwarding.py
@@ -18,8 +18,8 @@ from forward_monitor.formatter import AttachmentInfo, FormattedMessage, format_a
 from forward_monitor.monitor import (
     AnnouncementFormatter,
     ChannelContext,
-    _RunState,
     _forward_message,
+    _RunState,
     _sync_announcements,
 )
 from forward_monitor.types import DiscordMessage
@@ -86,6 +86,8 @@ class StubTelegram:
         self.sent.append((chat_id, f"document:{document}"))
         if caption:
             self.sent.append((chat_id, caption))
+
+
 @pytest.mark.asyncio
 async def test_forward_message_sends_extra_messages() -> None:
     context = ChannelContext(

--- a/tests/test_monitor_run.py
+++ b/tests/test_monitor_run.py
@@ -21,6 +21,7 @@ from forward_monitor.config import (
     TelegramSettings,
 )
 from forward_monitor.networking import ProxyPool
+from forward_monitor.types import DiscordMessage
 
 
 class DummySession:
@@ -217,8 +218,8 @@ async def test_sync_announcements_ignores_existing_history(
         formatting=mapping.formatting,
     )
 
-    backlog = [{"id": "100"}, {"id": "101"}]
-    new_messages = [{"id": "102"}]
+    backlog: list[DiscordMessage] = [{"id": "100"}, {"id": "101"}]
+    new_messages: list[DiscordMessage] = [{"id": "102"}]
     fetch_calls: list[str | None] = []
 
     async def fake_fetch_channel_messages(


### PR DESCRIPTION
## Summary
- keep test imports sorted to satisfy ruff
- annotate monitor run tests with DiscordMessage lists to align with type hints

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d33e51e750832ba34a2042a3d47047