### PR TITLE
Register Telegram bot commands via official API

### DIFF
--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Iterable
 from pathlib import Path
 
 from forward_monitor.config_store import ConfigStore
@@ -10,6 +11,7 @@ from forward_monitor.telegram import CommandContext, TelegramController
 class DummyAPI:
     def __init__(self) -> None:
         self.messages: list[str] = []
+        self.commands: list[tuple[str, str]] = []
 
     def set_proxy(self, proxy: str | None) -> None:
         return None
@@ -21,6 +23,9 @@ class DummyAPI:
     ) -> list[dict[str, object]]:
         await asyncio.sleep(0)
         return []
+
+    async def set_my_commands(self, commands: Iterable[tuple[str, str]]) -> None:
+        self.commands = list(commands)
 
     async def send_message(
         self,


### PR DESCRIPTION
## Summary
- add a Telegram Bot API wrapper for `setMyCommands` and register commands when the controller starts
- centralize Telegram command metadata for permission checks and `/help`
- extend controller tests to cover Bot API command registration

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_b_68d6b9ff4c28832ba573c51b85a63de8