### PR TITLE
Fix bench noop API to satisfy protocol

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -9,7 +9,7 @@ import time
 from html import escape
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Iterable
 
 if TYPE_CHECKING:
     from forward_monitor.models import ChannelConfig as ChannelConfigType
@@ -145,6 +145,9 @@ async def benchmark_forwarding(iterations: int) -> None:
             timeout: int = 30,
         ) -> list[dict[str, object]]:
             return []
+
+        async def set_my_commands(self, commands: Iterable[tuple[str, str]]) -> None:
+            return None
 
         async def send_message(
             self,

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Iterable
 from pathlib import Path
+from typing import Iterable
 
 from forward_monitor.config_store import ConfigStore
 from forward_monitor.telegram import CommandContext, TelegramController


### PR DESCRIPTION
## Summary
- add the missing `set_my_commands` implementation to the benchmark `_NoopAPI` so it satisfies `TelegramAPIProtocol`
- tidy test imports to keep Ruff happy

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d6bb9236a8832baadab5876bb276e8