### PR TITLE
Fix lint formatting and type issues from CI

### DIFF
--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -228,7 +228,14 @@ class ForwardMonitorApp:
                     host = parsed.hostname or ""
                     if parsed.port:
                         host = f"{host}:{parsed.port}"
-                    proxy_url = urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+                    components = (
+                        parsed.scheme,
+                        host,
+                        parsed.path,
+                        parsed.query,
+                        parsed.fragment,
+                    )
+                    proxy_url = urlunsplit(components)
                 else:
                     proxy_url = legacy_proxy
 


### PR DESCRIPTION
## Summary
- refactor proxy URL assembly to satisfy linting while preserving behavior
- streamline Telegram controller imports and long strings for lint compliance
- normalize status command string values before HTML escaping to keep type checks happy

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d6c2e14f30832b9da3e5dd2ccc628c