### PR TITLE
Add username-based admin management and modernize Telegram panel

### DIFF
--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -47,7 +47,14 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         api = DummyAPI()
 
         controller = TelegramController(api, store, on_change=lambda: None)
-        admin = CommandContext(chat_id=1, user_id=1, username="admin", args="", message={})
+        admin = CommandContext(
+            chat_id=1,
+            user_id=1,
+            username="admin",
+            handle="admin",
+            args="",
+            message={},
+        )
 
         await controller._dispatch("claim", admin)
         admin.args = "123 456 Label"


### PR DESCRIPTION
## Summary
- store admin records with optional usernames and remember Telegram handles for lookup
- update the Telegram controller to ignore non-admin requests, support /grant and /revoke by @username, and refresh the help/admin panels
- extend the test suite for the new admin workflow and username support

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d6c6c39140832bbb98aa14995271d5