### PR TITLE
Improve message formatting and delay configuration

### DIFF
--- a/src/forward_monitor/__main__.py
+++ b/src/forward_monitor/__main__.py
@@ -31,7 +31,10 @@ def main() -> None:
         )
 
     app = ForwardMonitorApp(db_path=Path(args.db_path), telegram_token=token)
-    asyncio.run(app.run())
+    try:
+        asyncio.run(app.run())
+    except KeyboardInterrupt:
+        logging.getLogger(__name__).info("Остановка по запросу пользователя")
 
 
 if __name__ == "__main__":

--- a/src/forward_monitor/formatting.py
+++ b/src/forward_monitor/formatting.py
@@ -155,7 +155,7 @@ def _chunk_text(text: str, limit: int, ellipsis: str) -> list[str]:
     return chunks
 
 
-_CHANNEL_MENTION_RE = re.compile(r"<#[0-9]+>")
+_CHANNEL_MENTION_RE = re.compile(r"<#([0-9]+)>")
 _EXTRA_SPACE_RE = re.compile(r"[ \t]{2,}")
 _TRIPLE_NEWLINES_RE = re.compile(r"\n{3,}")
 
@@ -163,7 +163,7 @@ _TRIPLE_NEWLINES_RE = re.compile(r"\n{3,}")
 def _sanitize_content(text: str) -> str:
     if not text:
         return ""
-    cleaned = _CHANNEL_MENTION_RE.sub("", text)
+    cleaned = _CHANNEL_MENTION_RE.sub(lambda match: f"#{match.group(1)}", text)
     cleaned = _EXTRA_SPACE_RE.sub(" ", cleaned)
     cleaned = _TRIPLE_NEWLINES_RE.sub("\n\n", cleaned)
     return cleaned.strip()

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -77,8 +77,8 @@ class RuntimeOptions:
     """Tunable behaviour of the monitor loop."""
 
     poll_interval: float = 2.0
-    min_delay_ms: int = 0
-    max_delay_ms: int = 0
+    min_delay_seconds: float = 0.0
+    max_delay_seconds: float = 0.0
     rate_per_second: float = 8.0
 
 

--- a/src/forward_monitor/utils.py
+++ b/src/forward_monitor/utils.py
@@ -25,3 +25,19 @@ class RateLimiter:
             if now < self._next_time:
                 await asyncio.sleep(self._next_time - now)
             self._next_time = time.perf_counter() + self._interval
+
+
+def parse_delay_setting(value: str | None, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    stripped = value.strip()
+    if not stripped:
+        return default
+    try:
+        if any(symbol in stripped for symbol in ".eE"):
+            parsed = float(stripped)
+        else:
+            parsed = float(int(stripped) / 1000)
+    except ValueError:
+        return default
+    return max(0.0, parsed)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -60,7 +60,7 @@ def test_formatting_chunks_long_text() -> None:
     assert len(formatted.extra_messages) >= 1
 
 
-def test_channel_mentions_removed_from_content() -> None:
+def test_channel_mentions_converted_in_content() -> None:
     channel = sample_channel()
     message = DiscordMessage(
         id="2",
@@ -75,5 +75,5 @@ def test_channel_mentions_removed_from_content() -> None:
 
     formatted = format_discord_message(message, channel)
 
-    assert "<#" not in formatted.text
+    assert "#1234567890" in formatted.text
     assert "See" in formatted.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from forward_monitor.utils import parse_delay_setting
+
+
+def test_parse_delay_setting_ms_backwards_compatibility() -> None:
+    assert parse_delay_setting("250", 0.0) == 0.25
+
+
+def test_parse_delay_setting_seconds_float() -> None:
+    assert parse_delay_setting("1.50", 0.0) == 1.5
+
+
+def test_parse_delay_setting_invalid_returns_default() -> None:
+    assert parse_delay_setting("not-a-number", 2.0) == 2.0


### PR DESCRIPTION
## Summary
- preserve Discord channel mentions when forwarding messages by converting them to readable #ID tags
- switch the configurable inter-message delay to seconds, update bot commands/status output, and keep backwards compatibility with stored millisecond values
- add graceful shutdown logging on Ctrl+C and cover the new delay parsing helper with tests

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d6ee800b20832bbc702f883107e8c0