### PR TITLE
Improve filter handling and settings reporting

### DIFF
--- a/src/forward_monitor/utils.py
+++ b/src/forward_monitor/utils.py
@@ -41,3 +41,15 @@ def parse_delay_setting(value: str | None, default: float = 0.0) -> float:
     except ValueError:
         return default
     return max(0.0, parsed)
+
+
+def normalize_username(username: str | None) -> str | None:
+    """Return a lowercase username without @ prefix."""
+
+    if username is None:
+        return None
+    normalized = username.strip()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    normalized = normalized.strip().lower()
+    return normalized or None

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -52,3 +52,22 @@ def test_filter_engine_blocks_stickers() -> None:
 
     assert decision.allowed is False
     assert decision.reason == "sticker_blocked"
+
+
+def test_filter_engine_allowed_and_blocked_senders_by_name() -> None:
+    allowed_config = FilterConfig(allowed_senders={"coded"})
+    allowed_engine = FilterEngine(allowed_config)
+
+    permitted = allowed_engine.evaluate(make_message(author_name="Coded", author_id="99"))
+    rejected = allowed_engine.evaluate(make_message(author_name="Other", author_id="99"))
+
+    assert permitted.allowed is True
+    assert rejected.allowed is False
+    assert rejected.reason == "sender_not_allowed"
+
+    blocked_config = FilterConfig(blocked_senders={"coded"})
+    blocked_engine = FilterEngine(blocked_config)
+    blocked = blocked_engine.evaluate(make_message(author_name="Coded", author_id="42"))
+
+    assert blocked.allowed is False
+    assert blocked.reason == "sender_blocked"


### PR DESCRIPTION
## Summary
- Normalize filter storage so whitelist/blacklist values ignore case and sender filters accept both IDs and usernames
- Extend Telegram filter commands with duplicate detection, mass clearing, clearer responses, and improved status output formatting
- Update the filter engine and regression tests to cover sender name handling and the new normalization helpers

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68d6fa10763c832bbc928d145bc58365