### PR TITLE
Support configuring Telegram thread IDs for channel forwarding

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -27,6 +27,7 @@ def _sample_channel() -> "ChannelConfigType":
     return ChannelConfig(
         discord_id="1",
         telegram_chat_id="2",
+        telegram_thread_id=None,
         label="Bench",
         formatting=FormattingOptions(max_length=1000, attachments_style="summary"),
         filters=FilterConfig(),
@@ -149,6 +150,7 @@ async def benchmark_forwarding(iterations: int) -> None:
             *,
             parse_mode: str | None = None,
             disable_preview: bool = True,
+            message_thread_id: int | None = None,
         ) -> None:
             return None
 
@@ -159,7 +161,12 @@ async def benchmark_forwarding(iterations: int) -> None:
 
     for _ in range(iterations):
         formatted = format_discord_message(message, channel)
-        await send_formatted(api, channel.telegram_chat_id, formatted)
+        await send_formatted(
+            api,
+            channel.telegram_chat_id,
+            formatted,
+            thread_id=channel.telegram_thread_id,
+        )
 
 
 def main() -> None:

--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -188,7 +188,12 @@ class ForwardMonitorApp:
             formatted = format_discord_message(msg, channel)
             await telegram_rate.wait()
             try:
-                await send_formatted(telegram_api, channel.telegram_chat_id, formatted)
+                await send_formatted(
+                    telegram_api,
+                    channel.telegram_chat_id,
+                    formatted,
+                    thread_id=channel.telegram_thread_id,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -44,6 +44,7 @@ class ChannelConfig:
 
     discord_id: str
     telegram_chat_id: str
+    telegram_thread_id: int | None
     label: str
     formatting: FormattingOptions
     filters: FilterConfig
@@ -61,6 +62,7 @@ class ChannelConfig:
         return ChannelConfig(
             discord_id=self.discord_id,
             telegram_chat_id=self.telegram_chat_id,
+            telegram_thread_id=self.telegram_thread_id,
             label=self.label,
             formatting=formatting or self.formatting,
             filters=filters or self.filters,

--- a/tests/test_attachments_style.py
+++ b/tests/test_attachments_style.py
@@ -8,6 +8,7 @@ def test_links_style_shows_urls() -> None:
     channel = ChannelConfig(
         discord_id="1",
         telegram_chat_id="2",
+        telegram_thread_id=None,
         label="Test",
         formatting=FormattingOptions(attachments_style="links"),
         filters=FilterConfig(),

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -10,9 +10,13 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     store.set_setting("formatting.disable_preview", "false")
     store.add_filter(0, "whitelist", "hello")
 
-    record = store.add_channel("123", "456", "Label")
+    record = store.add_channel("123", "456", "Label", telegram_thread_id=777)
     store.set_channel_option(record.id, "formatting.attachments_style", "links")
     store.set_last_message(record.id, "900")
+
+    stored_record = store.get_channel("123")
+    assert stored_record is not None
+    assert stored_record.telegram_thread_id == 777
 
     configs = store.load_channel_configurations()
     assert len(configs) == 1
@@ -22,6 +26,7 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     assert channel.formatting.attachments_style == "links"
     assert channel.filters.whitelist == {"hello"}
     assert channel.last_message_id == "900"
+    assert channel.telegram_thread_id == 777
 
 
 def test_filter_management(tmp_path: Path) -> None:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -9,6 +9,7 @@ def sample_channel(**overrides: object) -> ChannelConfig:
     channel = ChannelConfig(
         discord_id="123",
         telegram_chat_id="456",
+        telegram_thread_id=None,
         label="Label",
         formatting=formatting,
         filters=FilterConfig(),

--- a/tests/test_formatting_escape.py
+++ b/tests/test_formatting_escape.py
@@ -8,6 +8,7 @@ def test_markdown_escape_preserves_special_chars() -> None:
     channel = ChannelConfig(
         discord_id="1",
         telegram_chat_id="2",
+        telegram_thread_id=None,
         label="Test",
         formatting=FormattingOptions(),
         filters=FilterConfig(),

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -36,6 +36,7 @@ class DummyAPI:
         *,
         parse_mode: str | None = None,
         disable_preview: bool = True,
+        message_thread_id: int | None = None,
     ) -> None:
         self.messages.append(text)
 
@@ -80,9 +81,17 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         )
 
         await controller._dispatch("claim", admin)
-        admin.args = "123 456 Label"
+        admin.args = "123 456:789 Label"
         await controller._dispatch("add_channel", admin)
-        assert store.get_channel("123") is not None
+        record = store.get_channel("123")
+        assert record is not None
+        assert record.telegram_thread_id == 789
+
+        admin.args = "123 clear"
+        await controller._dispatch("set_thread", admin)
+        record = store.get_channel("123")
+        assert record is not None
+        assert record.telegram_thread_id is None
 
         admin.args = "123 on"
         await controller._dispatch("set_disable_preview", admin)

--- a/tests/test_telegram_controller.py
+++ b/tests/test_telegram_controller.py
@@ -36,6 +36,7 @@ class DummyAPI:
         *,
         parse_mode: str | None = None,
         disable_preview: bool = True,
+        message_thread_id: int | None = None,
     ) -> None:
         self.messages.append((chat_id, text))
 


### PR DESCRIPTION
## Summary
- add storage, migration, and runtime plumbing for per-channel Telegram thread IDs
- expose thread configuration in the Telegram bot (updated /add_channel and new /set_thread command) and show thread info in status/list output
- include thread IDs when sending messages and update benchmarks and tests accordingly

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68dcff91801c832b9013b981fc7d3be2