### PR TITLE
Handle Telegram chat membership and warm-start channels

### DIFF
--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -65,3 +65,24 @@ def test_filter_management(tmp_path: Path) -> None:
             "blocked_types",
         )
     )
+
+
+def test_channel_activation_and_lookup(tmp_path: Path) -> None:
+    store = ConfigStore(tmp_path / "activation.sqlite")
+
+    first = store.add_channel("1", "100", "First")
+    second = store.add_channel("2", "100", "Second")
+    third = store.add_channel("3", "200", "Third")
+
+    store.set_channel_active(first.id, False)
+    store.set_channel_active(second.id, True)
+    store.set_channel_active(third.id, False)
+
+    chat_channels = store.list_channels_by_chat("100")
+    assert {record.discord_id for record in chat_channels} == {"1", "2"}
+    assert {record.active for record in chat_channels} == {False, True}
+
+    store.set_channel_active(first.id, True)
+    updated = store.get_channel("1")
+    assert updated is not None
+    assert updated.active is True

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -6,7 +6,7 @@ from typing import Iterable, cast
 
 from forward_monitor.config_store import ConfigStore
 from forward_monitor.discord import DiscordClient, ProxyCheckResult, TokenCheckResult
-from forward_monitor.models import NetworkOptions
+from forward_monitor.models import DiscordMessage, NetworkOptions
 from forward_monitor.telegram import CommandContext, TelegramController
 
 
@@ -48,6 +48,26 @@ class DummyDiscordClient:
     def __init__(self) -> None:
         self.tokens: list[str] = []
         self.proxies: list[str | None] = []
+        self.set_tokens: list[str | None] = []
+        self.network_options: list[NetworkOptions] = []
+        self.fetch_requests: list[tuple[str, int, str | None]] = []
+        self.responses: dict[str, list[DiscordMessage]] = {}
+
+    def set_token(self, token: str | None) -> None:
+        self.set_tokens.append(token)
+
+    def set_network_options(self, options: NetworkOptions) -> None:
+        self.network_options.append(options)
+
+    async def fetch_messages(
+        self,
+        channel_id: str,
+        *,
+        limit: int = 50,
+        after: str | None = None,
+    ) -> tuple[DiscordMessage, ...]:
+        self.fetch_requests.append((channel_id, limit, after))
+        return tuple(self.responses.get(channel_id, []))
 
     async def verify_token(
         self, token: str, *, network: NetworkOptions | None = None


### PR DESCRIPTION
## Summary
- warm-start Discord polling so newly configured channels skip historical messages until a fresh ID is recorded
- react to Telegram `my_chat_member` updates by toggling channel activity and syncing the last seen message for connected chats
- extend configuration and controller tests to cover chat activation flows and stub Discord client behaviour

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68dd06af0e98832b9f9691b5a871835c