### PR TITLE
Stop forwarding old Discord history after linking channels

### DIFF
--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Mapping, Sequence
 
 
@@ -51,6 +52,7 @@ class ChannelConfig:
     last_message_id: str | None
     active: bool = True
     storage_id: int | None = None
+    added_at: datetime | None = None
 
     def with_updates(
         self,
@@ -58,6 +60,7 @@ class ChannelConfig:
         formatting: FormattingOptions | None = None,
         filters: FilterConfig | None = None,
         last_message_id: str | None = None,
+        added_at: datetime | None = None,
     ) -> "ChannelConfig":
         return ChannelConfig(
             discord_id=self.discord_id,
@@ -71,6 +74,7 @@ class ChannelConfig:
             ),
             active=self.active,
             storage_id=self.storage_id,
+            added_at=added_at if added_at is not None else self.added_at,
         )
 
 

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -11,12 +11,14 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     store.add_filter(0, "whitelist", "hello")
 
     record = store.add_channel("123", "456", "Label", telegram_thread_id=777)
+    assert record.added_at is not None
     store.set_channel_option(record.id, "formatting.attachments_style", "links")
     store.set_last_message(record.id, "900")
 
     stored_record = store.get_channel("123")
     assert stored_record is not None
     assert stored_record.telegram_thread_id == 777
+    assert stored_record.added_at is not None
 
     configs = store.load_channel_configurations()
     assert len(configs) == 1
@@ -27,6 +29,7 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     assert channel.filters.whitelist == {"hello"}
     assert channel.last_message_id == "900"
     assert channel.telegram_thread_id == 777
+    assert channel.added_at is not None
 
 
 def test_filter_management(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- record channel creation timestamps and last seen message when new links are created to avoid replaying old Discord history
- skip forwarding of messages older than the link time and halt processing as soon as configuration refreshes, preventing traffic after a channel is removed
- extend the Telegram controller and tests to cover the new bootstrap behaviour

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68dd0a88d3c4832b9a3c7486f9fcbd80