### PR TITLE
Add pinned monitoring mode and role-based filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ pip install -e .[dev]
 - `/set_disable_preview <discord_id|all> <on|off>` — управлять предпросмотром ссылок (админ).
 - `/set_max_length <discord_id|all> <число>` — ограничить длину сообщения и разбивать текст (админ).
 - `/set_attachments <discord_id|all> <summary|links>` — выбрать стиль блока вложений (админ).
-- `/add_filter <discord_id|all> <тип> <значение>` — добавить фильтр (`whitelist`, `blacklist`, `allowed_senders`, `blocked_senders`, `allowed_types`, `blocked_types`) (админ).
+- `/set_monitoring <discord_id|all> <messages|pinned>` — выбрать режим мониторинга (новые или закреплённые сообщения) (админ).
+- `/add_filter <discord_id|all> <тип> <значение>` — добавить фильтр (`whitelist`, `blacklist`, `allowed_senders`, `blocked_senders`, `allowed_types`, `blocked_types`, `allowed_roles`, `blocked_roles`) (админ).
 - `/clear_filter <discord_id|all> <тип> [значение]` — очистить фильтр целиком или по значению (админ).
 
 Команды `all` или `*` на месте идентификатора канала меняют глобальные значения для всех связок, а идентификатор `0` служит для глобальных фильтров.

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -61,6 +61,7 @@ def _sample_message() -> "DiscordMessageType":
         attachments=tuple(attachments),
         embeds=tuple(embeds),
         stickers=(),
+        role_ids=set(),
     )
 
 

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, Set
 
 
 @dataclass(slots=True)
@@ -27,6 +27,8 @@ class FilterConfig:
     blocked_senders: set[str] = field(default_factory=set)
     allowed_types: set[str] = field(default_factory=set)
     blocked_types: set[str] = field(default_factory=set)
+    allowed_roles: set[str] = field(default_factory=set)
+    blocked_roles: set[str] = field(default_factory=set)
 
     def merge(self, other: "FilterConfig") -> "FilterConfig":
         return FilterConfig(
@@ -36,6 +38,8 @@ class FilterConfig:
             blocked_senders=self.blocked_senders | other.blocked_senders,
             allowed_types=self.allowed_types | other.allowed_types,
             blocked_types=self.blocked_types | other.blocked_types,
+            allowed_roles=self.allowed_roles | other.allowed_roles,
+            blocked_roles=self.blocked_roles | other.blocked_roles,
         )
 
 
@@ -53,6 +57,8 @@ class ChannelConfig:
     active: bool = True
     storage_id: int | None = None
     added_at: datetime | None = None
+    pinned_only: bool = False
+    known_pinned_ids: Set[str] = field(default_factory=set)
 
     def with_updates(
         self,
@@ -75,6 +81,8 @@ class ChannelConfig:
             active=self.active,
             storage_id=self.storage_id,
             added_at=added_at if added_at is not None else self.added_at,
+            pinned_only=self.pinned_only,
+            known_pinned_ids=set(self.known_pinned_ids),
         )
 
 
@@ -110,6 +118,7 @@ class DiscordMessage:
     attachments: Sequence[Mapping[str, Any]]
     embeds: Sequence[Mapping[str, Any]]
     stickers: Sequence[Mapping[str, Any]]
+    role_ids: Set[str]
     timestamp: str | None = None
     edited_timestamp: str | None = None
 

--- a/tests/test_attachments_style.py
+++ b/tests/test_attachments_style.py
@@ -24,6 +24,7 @@ def test_links_style_shows_urls() -> None:
         attachments=({"url": "https://example.com/a.png", "filename": "a.png"},),
         embeds=(),
         stickers=(),
+        role_ids=set(),
     )
     formatted = format_discord_message(message, channel)
     body = formatted.text.replace("\\", "")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -37,6 +37,7 @@ def test_formatting_includes_label_and_author() -> None:
         ),
         embeds=(),
         stickers=(),
+        role_ids=set(),
     )
     formatted = format_discord_message(message, sample_channel())
     assert formatted.text.startswith("Label • Author")
@@ -56,6 +57,7 @@ def test_formatting_chunks_long_text() -> None:
         attachments=(),
         embeds=(),
         stickers=(),
+        role_ids=set(),
     )
     formatted = format_discord_message(message, channel)
     assert len(formatted.extra_messages) >= 1
@@ -72,6 +74,7 @@ def test_channel_mentions_converted_in_content() -> None:
         attachments=(),
         embeds=(),
         stickers=(),
+        role_ids=set(),
     )
 
     formatted = format_discord_message(message, channel)

--- a/tests/test_formatting_escape.py
+++ b/tests/test_formatting_escape.py
@@ -24,6 +24,7 @@ def test_markdown_escape_preserves_special_chars() -> None:
         attachments=(),
         embeds=(),
         stickers=(),
+        role_ids=set(),
     )
     formatted = format_discord_message(message, channel)
     assert "*bold* _italic_ [link](url)" in formatted.text

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -77,6 +77,10 @@ class DummyDiscordClient:
         self.fetch_calls.append((channel_id, limit, after))
         return list(self.messages)
 
+    async def fetch_pinned_messages(self, channel_id: str) -> list[DiscordMessage]:
+        self.fetch_calls.append((channel_id, 0, None))
+        return list(self.messages)
+
 
 def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
     async def runner() -> None:
@@ -95,6 +99,7 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
                 attachments=(),
                 embeds=(),
                 stickers=(),
+                role_ids=set(),
             )
         ]
 
@@ -137,6 +142,16 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         admin.args = "all links"
         await controller._dispatch("set_attachments", admin)
         assert store.get_setting("formatting.attachments_style") == "links"
+
+        admin.args = "123 pinned"
+        await controller._dispatch("set_monitoring", admin)
+        configs = store.load_channel_configurations()
+        assert configs[0].pinned_only is True
+
+        admin.args = "123 messages"
+        await controller._dispatch("set_monitoring", admin)
+        configs = store.load_channel_configurations()
+        assert configs[0].pinned_only is False
 
     import asyncio
 

--- a/tests/test_telegram_controller.py
+++ b/tests/test_telegram_controller.py
@@ -59,6 +59,9 @@ class DummyDiscordClient:
         self.proxies.append(getattr(network, "discord_proxy_url", None))
         return ProxyCheckResult(ok=True)
 
+    async def fetch_pinned_messages(self, channel_id: str) -> list[dict[str, object]]:
+        return []
+
 
 def test_controller_respects_admin_permissions(tmp_path: Path) -> None:
     async def runner() -> None:


### PR DESCRIPTION
## Summary
- validate filter types, add role-based allow and block filters, and expose the new capabilities through Telegram commands and docs
- add a pinned-only monitoring mode, command, and storage helpers while ensuring channel processing respects configuration refreshes
- update status output and tests to cover the new monitoring mode and filtering options

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68dd16e73924832bb05e217fee2e323d