### PR TITLE
Improve pinned sync handling and Telegram output styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -e .[dev]
 - `/revoke <id|@user>` — отозвать права (админ).
 
 ### Каналы
-- `/add_channel <discord_id> <telegram_chat> <название>` — создать связку и задать видимое имя (админ).
+- `/add_channel <discord_id> <telegram_chat[:thread]> <название> [messages|pinned]` — создать связку, задать видимое имя и сразу выбрать режим мониторинга (админ).
 - `/remove_channel <discord_id>` — удалить связку (админ).
 - `/list_channels` — список активных связок (админ).
 

--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -274,6 +274,17 @@ class ForwardMonitorApp:
 
         current_ids = {msg.id for msg in messages}
         previous_known = set(channel.known_pinned_ids)
+
+        if not channel.pinned_synced:
+            if channel.storage_id is not None:
+                self._store.set_known_pinned_messages(channel.storage_id, current_ids)
+                self._store.set_pinned_synced(channel.storage_id, synced=True)
+                channel.known_pinned_ids = set(current_ids)
+                channel.pinned_synced = True
+            else:
+                channel.pinned_synced = True
+            return
+
         new_ids = current_ids - previous_known
 
         if not messages:
@@ -339,7 +350,9 @@ class ForwardMonitorApp:
 
         if updated_known != channel.known_pinned_ids:
             self._store.set_known_pinned_messages(channel.storage_id, updated_known)
+            self._store.set_pinned_synced(channel.storage_id, synced=True)
             channel.known_pinned_ids = updated_known
+            channel.pinned_synced = True
 
     async def _sleep_within(self, runtime: RuntimeOptions) -> None:
         delay_seconds = 0.0

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -59,6 +59,7 @@ class ChannelConfig:
     added_at: datetime | None = None
     pinned_only: bool = False
     known_pinned_ids: Set[str] = field(default_factory=set)
+    pinned_synced: bool = False
 
     def with_updates(
         self,
@@ -83,6 +84,7 @@ class ChannelConfig:
             added_at=added_at if added_at is not None else self.added_at,
             pinned_only=self.pinned_only,
             known_pinned_ids=set(self.known_pinned_ids),
+            pinned_synced=self.pinned_synced,
         )
 
 

--- a/tests/test_attachments_style.py
+++ b/tests/test_attachments_style.py
@@ -28,5 +28,6 @@ def test_links_style_shows_urls() -> None:
     )
     formatted = format_discord_message(message, channel)
     body = formatted.text.replace("\\", "")
+    assert formatted.parse_mode == "HTML"
     assert "https://example.com/a.png" in body
-    assert "Вложения" not in body
+    assert "Ссылки на вложения" in body

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -34,13 +34,16 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     assert channel.added_at is not None
     assert channel.pinned_only is False
     assert channel.known_pinned_ids == set()
+    assert channel.pinned_synced is False
 
     store.set_channel_option(record.id, "monitoring.mode", "pinned")
     store.set_known_pinned_messages(record.id, ["10", "20"])
+    store.set_pinned_synced(record.id, synced=True)
     configs = store.load_channel_configurations()
     channel = configs[0]
     assert channel.pinned_only is True
     assert channel.known_pinned_ids == {"10", "20"}
+    assert channel.pinned_synced is True
 
 
 def test_filter_management(tmp_path: Path) -> None:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -40,7 +40,8 @@ def test_formatting_includes_label_and_author() -> None:
         role_ids=set(),
     )
     formatted = format_discord_message(message, sample_channel())
-    assert formatted.text.startswith("Label • Author")
+    assert formatted.parse_mode == "HTML"
+    assert formatted.text.startswith("<b>Label</b> • <b>Author</b>")
     assert "original content" in formatted.text
     assert "file.txt" in formatted.text
 
@@ -79,5 +80,6 @@ def test_channel_mentions_converted_in_content() -> None:
 
     formatted = format_discord_message(message, channel)
 
+    assert formatted.parse_mode == "HTML"
     assert "#1234567890" in formatted.text
     assert "See" in formatted.text

--- a/tests/test_formatting_escape.py
+++ b/tests/test_formatting_escape.py
@@ -27,4 +27,5 @@ def test_markdown_escape_preserves_special_chars() -> None:
         role_ids=set(),
     )
     formatted = format_discord_message(message, channel)
+    assert formatted.parse_mode == "HTML"
     assert "*bold* _italic_ [link](url)" in formatted.text

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -147,11 +147,20 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         await controller._dispatch("set_monitoring", admin)
         configs = store.load_channel_configurations()
         assert configs[0].pinned_only is True
+        assert configs[0].pinned_synced is True
 
         admin.args = "123 messages"
         await controller._dispatch("set_monitoring", admin)
         configs = store.load_channel_configurations()
         assert configs[0].pinned_only is False
+        assert configs[0].pinned_synced is False
+
+        admin.args = "999 111 Label pinned"
+        dummy_client.messages = []
+        await controller._dispatch("add_channel", admin)
+        configs = [cfg for cfg in store.load_channel_configurations() if cfg.discord_id == "999"]
+        assert configs and configs[0].pinned_only is True
+        assert configs[0].pinned_synced is True
 
     import asyncio
 

--- a/tests/test_telegram_controller.py
+++ b/tests/test_telegram_controller.py
@@ -141,7 +141,7 @@ def test_grant_admin_by_username(tmp_path: Path) -> None:
         )
         store.remember_user(newcomer_ctx.user_id, newcomer_ctx.handle)
         await controller._dispatch("status", newcomer_ctx)
-        assert any("Статус" in text for _, text in api.messages)
+        assert any("статус" in text.lower() for _, text in api.messages)
 
     asyncio.run(runner())
 


### PR DESCRIPTION
## Summary
- ensure pinned-only channels only relay new messages by tracking sync state and allowing /add_channel to choose the monitoring mode
- refresh Telegram rendering and status output with HTML styling and safe chunking to highlight authors, channels, and attachments
- update documentation and tests to reflect the new defaults and cover pinned-mode behaviour

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68dd2fed4f98832ba550839736c8ba4a