### PR TITLE
Improve Discord forwarding reliability

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -55,6 +55,7 @@ def _sample_message() -> "DiscordMessageType":
     return DiscordMessage(
         id="1",
         channel_id="1",
+        guild_id="1",
         author_id="1",
         author_name="Bench",
         content="foo" * 20,
@@ -156,6 +157,17 @@ async def benchmark_forwarding(iterations: int) -> None:
             return None
 
         async def answer_callback_query(self, callback_id: str, text: str) -> None:
+            return None
+
+        async def send_photo(
+            self,
+            chat_id: int | str,
+            photo: str,
+            *,
+            caption: str | None = None,
+            parse_mode: str | None = None,
+            message_thread_id: int | None = None,
+        ) -> None:
             return None
 
     api: TelegramAPIProtocol = _NoopAPI()

--- a/src/forward_monitor/config_store.py
+++ b/src/forward_monitor/config_store.py
@@ -813,4 +813,5 @@ def _formatting_from_options(
         max_length=int(options.get("max_length", "3500")),
         ellipsis=options.get("ellipsis", "…"),
         attachments_style=options.get("attachments_style", "summary"),
+        show_discord_link=options.get("show_discord_link", "false").lower() == "true",
     )

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -15,6 +15,7 @@ class FormattingOptions:
     max_length: int = 3500
     ellipsis: str = "…"
     attachments_style: str = "summary"
+    show_discord_link: bool = False
 
 
 @dataclass(slots=True)
@@ -114,6 +115,7 @@ class DiscordMessage:
 
     id: str
     channel_id: str
+    guild_id: str | None
     author_id: str
     author_name: str
     content: str
@@ -123,6 +125,7 @@ class DiscordMessage:
     role_ids: Set[str]
     timestamp: str | None = None
     edited_timestamp: str | None = None
+    message_type: int = 0
 
 
 @dataclass(slots=True)
@@ -133,3 +136,4 @@ class FormattedTelegramMessage:
     extra_messages: Sequence[str]
     parse_mode: str | None
     disable_preview: bool
+    image_urls: Sequence[str] = ()

--- a/tests/test_attachments_style.py
+++ b/tests/test_attachments_style.py
@@ -18,6 +18,7 @@ def test_links_style_shows_urls() -> None:
     message = DiscordMessage(
         id="1",
         channel_id="1",
+        guild_id="g",
         author_id="1",
         author_name="User",
         content="",
@@ -27,7 +28,6 @@ def test_links_style_shows_urls() -> None:
         role_ids=set(),
     )
     formatted = format_discord_message(message, channel)
-    body = formatted.text.replace("\\", "")
     assert formatted.parse_mode == "HTML"
-    assert "https://example.com/a.png" in body
-    assert "Ссылки на вложения" in body
+    assert formatted.image_urls == ("https://example.com/a.png",)
+    assert "Ссылки на вложения" not in formatted.text

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -12,6 +12,7 @@ def make_message(**kwargs: Any) -> DiscordMessage:
     return DiscordMessage(
         id=str(kwargs.get("id", "1")),
         channel_id=str(kwargs.get("channel_id", "10")),
+        guild_id=str(kwargs.get("guild_id", "20")),
         author_id=str(kwargs.get("author_id", "42")),
         author_name=str(kwargs.get("author_name", "User")),
         content=str(kwargs.get("content", "")),

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -25,6 +25,7 @@ def test_formatting_includes_label_and_author() -> None:
     message = DiscordMessage(
         id="1",
         channel_id="123",
+        guild_id="456",
         author_id="99",
         author_name="Author",
         content="original content",
@@ -52,6 +53,7 @@ def test_formatting_chunks_long_text() -> None:
     message = DiscordMessage(
         id="1",
         channel_id="123",
+        guild_id="456",
         author_id="99",
         author_name="Author",
         content="long text " * 20,
@@ -69,6 +71,7 @@ def test_channel_mentions_converted_in_content() -> None:
     message = DiscordMessage(
         id="2",
         channel_id="123",
+        guild_id="456",
         author_id="99",
         author_name="Author",
         content="See <#1234567890> for details",
@@ -83,3 +86,47 @@ def test_channel_mentions_converted_in_content() -> None:
     assert formatted.parse_mode == "HTML"
     assert "#1234567890" in formatted.text
     assert "See" in formatted.text
+
+
+def test_discord_link_appended_when_enabled() -> None:
+    channel = sample_channel()
+    channel.formatting.show_discord_link = True
+    message = DiscordMessage(
+        id="2",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert "https://discord.com/channels/999/123/2" in formatted.text
+
+
+def test_basic_markdown_translated_to_html() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="3",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="**Bold** __Underline__ ~~Strike~~ ||Spoiler||",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert "<b>Bold</b>" in formatted.text
+    assert "<u>Underline</u>" in formatted.text
+    assert "<s>Strike</s>" in formatted.text
+    assert "<tg-spoiler>Spoiler</tg-spoiler>" in formatted.text

--- a/tests/test_formatting_escape.py
+++ b/tests/test_formatting_escape.py
@@ -18,6 +18,7 @@ def test_markdown_escape_preserves_special_chars() -> None:
     message = DiscordMessage(
         id="1",
         channel_id="1",
+        guild_id="g",
         author_id="1",
         author_name="User",
         content="*bold* _italic_ [link](url)",

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -43,6 +43,17 @@ class DummyAPI:
     async def answer_callback_query(self, callback_id: str, text: str) -> None:
         return None
 
+    async def send_photo(
+        self,
+        chat_id: int | str,
+        photo: str,
+        *,
+        caption: str | None = None,
+        parse_mode: str | None = None,
+        message_thread_id: int | None = None,
+    ) -> None:
+        self.messages.append(f"PHOTO:{photo}")
+
 
 class DummyDiscordClient:
     def __init__(self) -> None:
@@ -50,6 +61,8 @@ class DummyDiscordClient:
         self.proxies: list[str | None] = []
         self.fetch_calls: list[tuple[str, int, str | None]] = []
         self.messages: list[DiscordMessage] = []
+        self.checked_channels: list[str] = []
+        self.existing_channels: set[str] | None = None
 
     def set_token(self, token: str | None) -> None:
         self.tokens.append(token or "")
@@ -81,6 +94,12 @@ class DummyDiscordClient:
         self.fetch_calls.append((channel_id, 0, None))
         return list(self.messages)
 
+    async def check_channel_exists(self, channel_id: str) -> bool:
+        self.checked_channels.append(channel_id)
+        if self.existing_channels is None:
+            return True
+        return channel_id in self.existing_channels
+
 
 def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
     async def runner() -> None:
@@ -93,6 +112,7 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
             DiscordMessage(
                 id="100",
                 channel_id="123",
+                guild_id="guild",
                 author_id="1",
                 author_name="tester",
                 content="",
@@ -121,6 +141,7 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         await controller._dispatch("claim", admin)
         admin.args = "123 456:789 Label"
         await controller._dispatch("add_channel", admin)
+        assert "123" in dummy_client.checked_channels
         record = store.get_channel("123")
         assert record is not None
         assert record.telegram_thread_id == 789
@@ -143,6 +164,10 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         await controller._dispatch("set_attachments", admin)
         assert store.get_setting("formatting.attachments_style") == "links"
 
+        admin.args = "all on"
+        await controller._dispatch("set_discord_link", admin)
+        assert store.get_setting("formatting.show_discord_link") == "true"
+
         admin.args = "123 pinned"
         await controller._dispatch("set_monitoring", admin)
         configs = store.load_channel_configurations()
@@ -158,9 +183,97 @@ def test_controller_adds_channel_and_updates_formatting(tmp_path: Path) -> None:
         admin.args = "999 111 Label pinned"
         dummy_client.messages = []
         await controller._dispatch("add_channel", admin)
+        assert "999" in dummy_client.checked_channels
         configs = [cfg for cfg in store.load_channel_configurations() if cfg.discord_id == "999"]
         assert configs and configs[0].pinned_only is True
         assert configs[0].pinned_synced is True
+
+    import asyncio
+
+    asyncio.run(runner())
+
+
+def test_send_recent_forwards_messages(tmp_path: Path) -> None:
+    async def runner() -> None:
+        store = ConfigStore(tmp_path / "db.sqlite")
+        store.set_setting("discord.token", "token")
+        api = DummyAPI()
+        dummy_client = DummyDiscordClient()
+        dummy_client.existing_channels = {"123"}
+        dummy_client.messages = [
+            DiscordMessage(
+                id="100",
+                channel_id="123",
+                guild_id="guild",
+                author_id="1",
+                author_name="tester",
+                content="",
+                attachments=(),
+                embeds=(),
+                stickers=(),
+                role_ids=set(),
+            )
+        ]
+
+        controller = TelegramController(
+            api,
+            store,
+            discord_client=cast(DiscordClient, dummy_client),
+            on_change=lambda: None,
+        )
+        admin = CommandContext(
+            chat_id=1,
+            user_id=1,
+            username="admin",
+            handle="admin",
+            args="",
+            message={},
+        )
+
+        await controller._dispatch("claim", admin)
+        admin.args = "123 456 Label"
+        await controller._dispatch("add_channel", admin)
+
+        dummy_client.messages = [
+            DiscordMessage(
+                id="101",
+                channel_id="123",
+                guild_id="guild",
+                author_id="2",
+                author_name="Alice",
+                content="**Bold text**",
+                attachments=(),
+                embeds=(),
+                stickers=(),
+                role_ids=set(),
+            ),
+            DiscordMessage(
+                id="102",
+                channel_id="123",
+                guild_id="guild",
+                author_id="3",
+                author_name="Bob",
+                content="",
+                attachments=(
+                    {"url": "https://cdn.example.com/image.png", "filename": "image.png"},
+                ),
+                embeds=(),
+                stickers=(),
+                role_ids=set(),
+            ),
+        ]
+        api.messages.clear()
+
+        admin.args = "2 123"
+        await controller._dispatch("send_recent", admin)
+
+        record = store.get_channel("123")
+        assert record is not None
+        assert record.last_message_id == "102"
+        assert any(message.startswith("PHOTO:") for message in api.messages)
+        assert any("<b>Bold text</b>" in message for message in api.messages)
+        assert any("Всего переслано: 2" in message for message in api.messages)
+        assert ("123", 2, None) in dummy_client.fetch_calls
 
     import asyncio
 

--- a/tests/test_telegram_controller.py
+++ b/tests/test_telegram_controller.py
@@ -43,6 +43,17 @@ class DummyAPI:
     async def answer_callback_query(self, callback_id: str, text: str) -> None:
         return None
 
+    async def send_photo(
+        self,
+        chat_id: int | str,
+        photo: str,
+        *,
+        caption: str | None = None,
+        parse_mode: str | None = None,
+        message_thread_id: int | None = None,
+    ) -> None:
+        self.messages.append((chat_id, f"PHOTO:{photo}"))
+
 
 class DummyDiscordClient:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- validate Discord channels before linking and add a /send_recent command for manual backfill
- harden message handling by ignoring system entries, anchoring bootstrap to snowflakes, and optionally appending Discord links
- clean formatting by translating basic markdown, stripping custom emojis, and treating image attachments as Telegram photos

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e3aacb4714832b8fe3f5bcefab2bc1