### PR TITLE
Fix lint failure in health monitoring log message

### DIFF
--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -310,7 +310,11 @@ class ForwardMonitorApp:
                 continue
             self._health_status[update.key] = update.status
             if update.status == "error":
-                logger.warning("Проблема со здоровьем компонента %s: %s", update.key, update.message)
+                logger.warning(
+                    "Проблема со здоровьем компонента %s: %s",
+                    update.key,
+                    update.message,
+                )
                 message = self._format_health_alert(update, recovered=False)
                 await self._notify_admins(telegram_api, message)
             elif previous == "error" and update.status == "ok":


### PR DESCRIPTION
## Summary
- wrap the health warning log call to comply with the project line-length limit

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e3c3f314c0832bb6423afe1e32065d