### PR TITLE
Improve health gating and Telegram formatting

### DIFF
--- a/src/forward_monitor/config_store.py
+++ b/src/forward_monitor/config_store.py
@@ -640,6 +640,10 @@ class ConfigStore:
             pinned_only, known_pinned_ids, pinned_synced = _monitoring_from_options(
                 defaults.get("monitoring", {}), channel_options
             )
+            health_status, health_message = self.get_health_status(
+                f"channel.{record.discord_id}"
+            )
+            blocked_by_health = health_status == "error" and record.active
             configs.append(
                 ChannelConfig(
                     discord_id=record.discord_id,
@@ -655,6 +659,9 @@ class ConfigStore:
                     pinned_only=pinned_only,
                     known_pinned_ids=known_pinned_ids,
                     pinned_synced=pinned_synced,
+                    health_status=health_status,
+                    health_message=health_message,
+                    blocked_by_health=blocked_by_health,
                 )
             )
         return configs

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -61,6 +61,9 @@ class ChannelConfig:
     pinned_only: bool = False
     known_pinned_ids: Set[str] = field(default_factory=set)
     pinned_synced: bool = False
+    health_status: str = "unknown"
+    health_message: str | None = None
+    blocked_by_health: bool = False
 
     def with_updates(
         self,
@@ -86,6 +89,9 @@ class ChannelConfig:
             pinned_only=self.pinned_only,
             known_pinned_ids=set(self.known_pinned_ids),
             pinned_synced=self.pinned_synced,
+            health_status=self.health_status,
+            health_message=self.health_message,
+            blocked_by_health=self.blocked_by_health,
         )
 
 
@@ -123,6 +129,9 @@ class DiscordMessage:
     embeds: Sequence[Mapping[str, Any]]
     stickers: Sequence[Mapping[str, Any]]
     role_ids: Set[str]
+    mention_users: Mapping[str, str] = field(default_factory=dict)
+    mention_roles: Mapping[str, str] = field(default_factory=dict)
+    mention_channels: Mapping[str, str] = field(default_factory=dict)
     timestamp: str | None = None
     edited_timestamp: str | None = None
     message_type: int = 0

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -39,12 +39,16 @@ def test_formatting_includes_label_and_author() -> None:
         embeds=(),
         stickers=(),
         role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
     )
     formatted = format_discord_message(message, sample_channel())
     assert formatted.parse_mode == "HTML"
-    assert formatted.text.startswith("<b>Label</b> • <b>Author</b>")
+    assert formatted.text.startswith("📣 <b>Label</b>")
+    assert "💬 <b>Новое сообщение</b>" in formatted.text
+    assert "👤 <b>Author</b>" in formatted.text
     assert "original content" in formatted.text
     assert "file.txt" in formatted.text
+    assert "📅 <b>02.01.2024 03:04 UTC</b>" in formatted.text
 
 
 def test_formatting_chunks_long_text() -> None:
@@ -79,12 +83,14 @@ def test_channel_mentions_converted_in_content() -> None:
         embeds=(),
         stickers=(),
         role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
     )
+    message.mention_channels = {"1234567890": "general"}
 
     formatted = format_discord_message(message, channel)
 
     assert formatted.parse_mode == "HTML"
-    assert "#1234567890" in formatted.text
+    assert "#general" in formatted.text
     assert "See" in formatted.text
 
 
@@ -102,11 +108,13 @@ def test_discord_link_appended_when_enabled() -> None:
         embeds=(),
         stickers=(),
         role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
     )
 
     formatted = format_discord_message(message, channel)
 
     assert "https://discord.com/channels/999/123/2" in formatted.text
+    assert "Открыть в Discord" in formatted.text
 
 
 def test_basic_markdown_translated_to_html() -> None:
@@ -122,6 +130,7 @@ def test_basic_markdown_translated_to_html() -> None:
         embeds=(),
         stickers=(),
         role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
     )
 
     formatted = format_discord_message(message, channel)
@@ -130,3 +139,50 @@ def test_basic_markdown_translated_to_html() -> None:
     assert "<u>Underline</u>" in formatted.text
     assert "<s>Strike</s>" in formatted.text
     assert "<tg-spoiler>Spoiler</tg-spoiler>" in formatted.text
+
+
+def test_pinned_header_icon() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="5",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="Pinned text",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
+    )
+
+    formatted = format_discord_message(message, channel, message_kind="pinned")
+
+    assert "📌 <b>Закреплённое сообщение</b>" in formatted.text
+
+
+def test_mentions_display_names() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="4",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="Hi <@555> and role <@&777> in <#888>",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
+    )
+    message.mention_users = {"555": "UserName"}
+    message.mention_roles = {"777": "Moderators"}
+    message.mention_channels = {"888": "general"}
+
+    formatted = format_discord_message(message, channel)
+
+    assert "@UserName" in formatted.text
+    assert "@Moderators" in formatted.text
+    assert "#general" in formatted.text

--- a/tests/test_formatting_escape.py
+++ b/tests/test_formatting_escape.py
@@ -21,12 +21,14 @@ def test_markdown_escape_preserves_special_chars() -> None:
         guild_id="g",
         author_id="1",
         author_name="User",
-        content="*bold* _italic_ [link](url)",
+        content="*bold* _italic_ [link](https://example.com)",
         attachments=(),
         embeds=(),
         stickers=(),
         role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
     )
     formatted = format_discord_message(message, channel)
     assert formatted.parse_mode == "HTML"
-    assert "*bold* _italic_ [link](url)" in formatted.text
+    assert "*bold* _italic_" in formatted.text
+    assert '<a href="https://example.com">link</a>' in formatted.text


### PR DESCRIPTION
## Summary
- aggregate health alerts and block unhealthy channels during monitoring
- enhance Telegram formatting with emoji headers, timestamps, and better mention/link handling
- expand Telegram help output and respect health status in manual resend commands

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e3db638284832b8ea940b6f50915b2