### PR TITLE
Improve startup health checks and manual forwarding support

### DIFF
--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -255,6 +255,9 @@ class ForwardMonitorApp:
     ) -> None:
         updates: list[HealthUpdate] = []
 
+        discord_client.set_token(state.discord_token)
+        discord_client.set_network_options(state.network)
+
         proxy_result = await discord_client.check_proxy(state.network)
         if state.network.discord_proxy_url:
             proxy_status = "ok" if proxy_result.ok else "error"


### PR DESCRIPTION
## Summary
- ensure the health checker configures the Discord client before running checks to avoid erroneous startup alarms
- backfill channel timestamps, record /send_recent activity in the store, and surface the latest manual run details via /status
- extend /send_recent to support pinned-channel forwarding and persist manual activity while showing Discord link settings in status output

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e3fd27d0d8832b9ba01e1129c01241