### PR TITLE
Add configurable health checks and refine manual forwarding

### DIFF
--- a/src/forward_monitor/discord.py
+++ b/src/forward_monitor/discord.py
@@ -137,6 +137,11 @@ class DiscordClient:
                         await resp.read()
                         return True
                     if status in {401, 403, 404}:
+                        logger.info(
+                            "Discord ответил статусом %s при проверке канала %s", status, channel_id
+                        )
+                        return False
+                    if status >= 400:
                         logger.warning(
                             "Discord ответил статусом %s при проверке канала %s", status, channel_id
                         )

--- a/src/forward_monitor/formatting.py
+++ b/src/forward_monitor/formatting.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping, Sequence
 from urllib.parse import urlparse
 
 from .models import ChannelConfig, DiscordMessage, FormattedTelegramMessage
+from .utils import as_moscow_time
 
 EmbedPayload = Mapping[str, Any]
 AttachmentPayload = Mapping[str, Any]
@@ -93,7 +94,7 @@ def _format_timestamp_line(message: DiscordMessage) -> str:
     moment = _parse_timestamp(message.edited_timestamp or message.timestamp)
     if moment is None:
         moment = datetime.now(timezone.utc)
-    formatted = moment.astimezone(timezone.utc).strftime("%d.%m.%Y %H:%M UTC")
+    formatted = as_moscow_time(moment).strftime("%d.%m.%Y %H:%M %Z")
     return f"📅 <b>{_escape(formatted)}</b>"
 
 

--- a/src/forward_monitor/models.py
+++ b/src/forward_monitor/models.py
@@ -103,6 +103,7 @@ class RuntimeOptions:
     min_delay_seconds: float = 0.0
     max_delay_seconds: float = 0.0
     rate_per_second: float = 8.0
+    healthcheck_interval: float = 180.0
 
 
 @dataclass(slots=True)

--- a/src/forward_monitor/utils.py
+++ b/src/forward_monitor/utils.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime, timedelta, timezone
+
+try:  # pragma: no cover - zoneinfo availability depends on platform
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback for environments without tzdata
+    ZoneInfo = None  # type: ignore[misc,assignment]
 
 
 class RateLimiter:
@@ -53,3 +59,17 @@ def normalize_username(username: str | None) -> str | None:
         normalized = normalized[1:]
     normalized = normalized.strip().lower()
     return normalized or None
+
+
+if ZoneInfo is not None:  # pragma: no cover - executed when tzdata available
+    MOSCOW_TIMEZONE = ZoneInfo("Europe/Moscow")
+else:  # pragma: no cover - fallback branch for limited platforms
+    MOSCOW_TIMEZONE = timezone(timedelta(hours=3))
+
+
+def as_moscow_time(moment: datetime) -> datetime:
+    """Return ``moment`` converted to the Moscow timezone."""
+
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(MOSCOW_TIMEZONE)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -95,7 +95,7 @@ async def _run_monitor_with_health(
         app._healthcheck_loop(
             cast(DiscordClient, discord),
             cast(TelegramAPI, telegram),
-            interval=0.05,
+            interval_override=0.05,
         )
     )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -48,7 +48,7 @@ def test_formatting_includes_label_and_author() -> None:
     assert "👤 <b>Author</b>" in formatted.text
     assert "original content" in formatted.text
     assert "file.txt" in formatted.text
-    assert "📅 <b>02.01.2024 03:04 UTC</b>" in formatted.text
+    assert "📅 <b>02.01.2024 06:04 MSK</b>" in formatted.text
 
 
 def test_formatting_chunks_long_text() -> None:


### PR DESCRIPTION
## Summary
- allow configuring the health check interval via the new /set_healthcheck command, persist the value, and display it in /status while using it to pace the scheduler
- adjust /send_recent to forward only unseen content, update channel state safely, and chunk long summaries so Telegram always acknowledges the command
- switch human-facing timestamps to Moscow time and downgrade Discord 403 health-check logs to reduce noise

## Testing
- pytest
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e409d88754832bb09c5c597642faf7