### PR TITLE
Normalize Discord tokens and allow bot credentials

### DIFF
--- a/src/forward_monitor/app.py
+++ b/src/forward_monitor/app.py
@@ -282,6 +282,14 @@ class ForwardMonitorApp:
         token_result = await discord_client.verify_token(token, network=state.network)
         token_status = "ok" if token_result.ok else "error"
         token_message = token_result.error
+        if token_result.ok and token_result.normalized_token:
+            normalized = token_result.normalized_token
+            if normalized != token:
+                self._store.set_setting("discord.token", normalized)
+                token = normalized
+                state.discord_token = normalized
+                discord_client.set_token(normalized)
+                self._signal_refresh()
         updates.append(
             HealthUpdate(
                 key="discord_token",

--- a/src/forward_monitor/telegram.py
+++ b/src/forward_monitor/telegram.py
@@ -1102,12 +1102,6 @@ class TelegramController:
         if not token:
             await self._api.send_message(ctx.chat_id, "Нужно передать токен")
             return
-        if token.lower().startswith("bot "):
-            await self._api.send_message(
-                ctx.chat_id,
-                "Укажите пользовательский токен без префикса Bot.",
-            )
-            return
 
         network = self._store.load_network_options()
         result = await self._discord.verify_token(token, network=network)
@@ -1118,7 +1112,8 @@ class TelegramController:
             )
             return
 
-        self._store.set_setting("discord.token", token)
+        stored_value = result.normalized_token or token
+        self._store.set_setting("discord.token", stored_value)
         self._on_change()
         display = result.display_name or "пользователь"
         await self._api.send_message(


### PR DESCRIPTION
## Summary
- normalize Discord tokens during verification so bot credentials gain the required `Bot ` prefix automatically
- persist normalized tokens during health checks and Telegram commands to refresh the running configuration
- extend tests to cover token normalization in both the controller and health checker flows

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e40f6b2268832b94730af042f96e9d