### PR TITLE
Improve manual forwarding and health checks

### DIFF
--- a/src/forward_monitor/discord.py
+++ b/src/forward_monitor/discord.py
@@ -62,6 +62,7 @@ class DiscordClient:
         *,
         limit: int = 50,
         after: str | None = None,
+        before: str | None = None,
     ) -> Sequence[DiscordMessage]:
         if not self._token:
             return []
@@ -69,6 +70,8 @@ class DiscordClient:
         params = {"limit": str(max(1, min(limit, 100)))}
         if after:
             params["after"] = after
+        if before:
+            params["before"] = before
 
         headers = {
             "Authorization": self._token,

--- a/src/forward_monitor/formatting.py
+++ b/src/forward_monitor/formatting.py
@@ -277,6 +277,7 @@ _CUSTOM_EMOJI_RE = re.compile(r"<a?:[a-zA-Z0-9_~]+:[0-9]+>")
 _EXTRA_SPACE_RE = re.compile(r"[ \t]{2,}")
 _TRIPLE_NEWLINES_RE = re.compile(r"\n{3,}")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_ANGLE_LINK_RE = re.compile(r"<(https?://[^\s<>]+)>")
 _ALLOWED_LINK_SCHEMES = {"http", "https"}
 
 
@@ -296,6 +297,7 @@ def _sanitize_content(text: str, message: DiscordMessage | None = None) -> str:
         )
     else:
         cleaned = _CHANNEL_MENTION_RE.sub(lambda match: f"#{match.group(1)}", cleaned)
+    cleaned = _ANGLE_LINK_RE.sub(r"\1", cleaned)
     cleaned = _CUSTOM_EMOJI_RE.sub("", cleaned)
     cleaned = _EXTRA_SPACE_RE.sub(" ", cleaned)
     cleaned = _TRIPLE_NEWLINES_RE.sub("\n\n", cleaned)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -186,3 +186,25 @@ def test_mentions_display_names() -> None:
     assert "@UserName" in formatted.text
     assert "@Moderators" in formatted.text
     assert "#general" in formatted.text
+
+
+def test_angle_bracket_links_are_unwrapped() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="5",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="Visit <https://example.com> for details",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+        timestamp="2024-01-02T03:04:05+00:00",
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert "<https://example.com>" not in formatted.text
+    assert "https://example.com" in formatted.text


### PR DESCRIPTION
## Summary
- adjust manual /send_recent logic to fetch newest messages first, fall back to history, and respect pinned forwarding updates
- relax health check flow to skip token and channel lookups when the configured proxy is down and avoid unnecessary requests
- normalize angle-bracket links in message formatting and extend coverage with regression tests

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e41a28f060832b9593cba7536abdb9