### PR TITLE
Fix /send_recent limit handling

### DIFF
--- a/src/forward_monitor/telegram.py
+++ b/src/forward_monitor/telegram.py
@@ -1776,9 +1776,13 @@ class TelegramController:
                 continue
 
             ordered = sorted(messages, key=lambda msg: sort_key(msg.id), reverse=True)
-            subset = ordered[:limit]
+            candidates = [msg for msg in ordered if is_newer(msg.id, marker)]
+            subset = candidates[:limit]
             if not subset:
-                _record("сообщения не найдены")
+                if marker is None:
+                    _record("сообщения не найдены")
+                else:
+                    _record("новых сообщений не найдено")
                 continue
             engine = FilterEngine(channel.filters)
             last_seen = marker
@@ -1829,7 +1833,7 @@ class TelegramController:
                 self._store.set_last_message(channel.storage_id, last_seen)
                 state_changed = True
 
-            total_candidates = len(ordered)
+            total_candidates = len(candidates)
             processed_candidates = len(subset)
             if forwarded:
                 note_parts = [

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -589,14 +589,14 @@ def test_send_recent_only_new_messages(tmp_path: Path) -> None:
         assert any("new-three" in message for message in api.messages)
         assert any("new-two" in message for message in api.messages)
         assert all("new-one" not in message for message in api.messages)
-        assert any("осталось ещё 2 сообщений" in message for message in api.messages)
+        assert any("осталось ещё 1 сообщений" in message for message in api.messages)
 
     import asyncio
 
     asyncio.run(runner())
 
 
-def test_send_recent_includes_history_when_needed(tmp_path: Path) -> None:
+def test_send_recent_ignores_history_when_not_requested(tmp_path: Path) -> None:
     async def runner() -> None:
         store = ConfigStore(tmp_path / "db.sqlite")
         store.set_setting("discord.token", "token")
@@ -686,8 +686,10 @@ def test_send_recent_includes_history_when_needed(tmp_path: Path) -> None:
         joined = "\n".join(api.messages)
         assert "fresh-top" in joined
         assert "fresh-second" in joined
-        assert "history-first" in joined
-        assert any("осталось ещё 1 сообщений" in message for message in api.messages)
+        assert "history-first" not in joined
+        assert not any(
+            "осталось ещё" in message for message in api.messages
+        )
 
     import asyncio
 


### PR DESCRIPTION
## Summary
- ensure `/send_recent` only considers Discord messages newer than the stored marker so manual forwarding respects the requested limit
- adjust the command tests to reflect the stricter behaviour and verify that old history is ignored

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e426c8aa80832b9fe380e5b6529a41