### PR TITLE
Persist Telegram offset and skip pre-start messages

### DIFF
--- a/src/forward_monitor/config_store.py
+++ b/src/forward_monitor/config_store.py
@@ -211,6 +211,23 @@ class ConfigStore:
             cur.execute("DELETE FROM settings WHERE key=?", (key,))
             self._conn.commit()
 
+    def set_telegram_offset(self, offset: int) -> None:
+        safe_value = max(0, int(offset))
+        self.set_setting("state.telegram.offset", str(safe_value))
+
+    def get_telegram_offset(self) -> int | None:
+        value = self.get_setting("state.telegram.offset")
+        if value is None:
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return max(0, parsed)
+
+    def clear_telegram_offset(self) -> None:
+        self.delete_setting("state.telegram.offset")
+
     def iter_settings(self, prefix: str | None = None) -> Iterator[tuple[str, str]]:
         query = "SELECT key, value FROM settings"
         params: tuple[str, ...] = ()

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -47,6 +47,24 @@ def test_channel_lifecycle(tmp_path: Path) -> None:
     assert channel.pinned_synced is True
 
 
+def test_telegram_offset_helpers(tmp_path: Path) -> None:
+    store = ConfigStore(tmp_path / "offsets.sqlite")
+
+    assert store.get_telegram_offset() is None
+
+    store.set_telegram_offset(120)
+    assert store.get_telegram_offset() == 120
+
+    store.set_telegram_offset(-5)
+    assert store.get_telegram_offset() == 0
+
+    store.clear_telegram_offset()
+    assert store.get_telegram_offset() is None
+
+    store.set_setting("state.telegram.offset", "not-a-number")
+    assert store.get_telegram_offset() is None
+
+
 def test_filter_management(tmp_path: Path) -> None:
     store = ConfigStore(tmp_path / "filters.sqlite")
 


### PR DESCRIPTION
## Summary
- persist the Telegram polling offset in the SQLite store so restarts resume from the latest processed update
- treat the monitor startup time as the baseline when a channel has no last message, avoiding floods of historical Discord messages
- cover the new persistence and bootstrap behaviour with targeted tests

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e42bfe7484832badb78cd3ee646abf