### PR TITLE
Improve formatting sanitization and healthcheck retries

### DIFF
--- a/src/forward_monitor/telegram.py
+++ b/src/forward_monitor/telegram.py
@@ -1681,6 +1681,14 @@ class TelegramController:
             await self._api.send_message(ctx.chat_id, "Каналы не настроены")
             return
 
+        await self._api.send_message(
+            ctx.chat_id,
+            (
+                f"Пересылка запущена (каналов: {len(selected)}, лимит: {limit}). "
+                "Это может занять несколько минут."
+            ),
+        )
+
         rate_setting = self._store.get_setting("runtime.rate")
         try:
             rate_value = float(rate_setting) if rate_setting is not None else 8.0

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -43,7 +43,7 @@ def test_formatting_includes_label_and_author() -> None:
     )
     formatted = format_discord_message(message, sample_channel())
     assert formatted.parse_mode == "HTML"
-    assert formatted.text.startswith("<b>━━━━━━━━")
+    assert formatted.text.startswith("<b>────── ✦ ──────</b>")
     assert "📣 <b>Label</b>" in formatted.text
     assert "💬 <b>Новое сообщение</b>" in formatted.text
     assert "👤 <b>Author</b>" in formatted.text
@@ -162,6 +162,51 @@ def test_pinned_header_icon() -> None:
     formatted = format_discord_message(message, channel, message_kind="pinned")
 
     assert "📌 <b>Закреплённое сообщение</b>" in formatted.text
+
+
+def test_markdown_escapes_are_removed() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="6",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="\\#TOKEN2049Singapore takeaways\n1\\.\n2\\.",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert "\\#" not in formatted.text
+    assert "#TOKEN2049Singapore takeaways" in formatted.text
+    assert "1." in formatted.text
+    assert "2." in formatted.text
+
+
+def test_id_tags_and_timestamps_are_formatted() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="7",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="<id:guide> <id:customize> <t:1757318400:f>",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert "#guide" in formatted.text
+    assert "#customize" in formatted.text
+    assert "08.09.2025 11:00 MSK" in formatted.text
 
 
 def test_mentions_display_names() -> None:

--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -488,6 +488,10 @@ def test_send_recent_forwards_messages(tmp_path: Path) -> None:
         record = store.get_channel("123")
         assert record is not None
         assert record.last_message_id == "102"
+        assert api.messages
+        assert api.messages[0] == (
+            "Пересылка запущена (каналов: 1, лимит: 2). Это может занять несколько минут."
+        )
         assert any(message.startswith("PHOTO:") for message in api.messages)
         assert any("<b>Bold text</b>" in message for message in api.messages)
         assert any("Всего переслано: 2" in message for message in api.messages)


### PR DESCRIPTION
## Summary
- replace the HTML separator with a mobile-friendly variant and sanitize Discord artefacts such as escaped markdown, ID tags, and timestamp mentions
- notify admins when manual forwarding starts and cover the new behaviour with formatting/command tests
- retry health checks before surfacing failures to cut down on transient health notifications

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e52c2bb2c8832b9c8177026d2c9ea6