### PR TITLE
Link numeric hashtags and cover Telegram image forwarding

### DIFF
--- a/src/forward_monitor/formatting.py
+++ b/src/forward_monitor/formatting.py
@@ -378,6 +378,7 @@ def _apply_basic_markdown(text: str) -> str:
     escaped = _UNDERLINE_RE.sub(lambda m: f"<u>{m.group(1)}</u>", escaped)
     escaped = _STRIKE_RE.sub(lambda m: f"<s>{m.group(1)}</s>", escaped)
     escaped = _SPOILER_RE.sub(lambda m: f"<tg-spoiler>{m.group(1)}</tg-spoiler>", escaped)
+    escaped = _NUMERIC_HASHTAG_RE.sub(_format_numeric_hashtag, escaped)
 
     result = escaped
     for token, value in placeholders.items():
@@ -390,6 +391,15 @@ def _format_generic_id_tag(raw: str) -> str:
     if not cleaned:
         return ""
     return f"#{cleaned}"
+
+
+def _format_numeric_hashtag(match: re.Match[str]) -> str:
+    value = match.group(1)
+    if not value:
+        return match.group(0)
+    return (
+        f"<a href=\"https://t.me/s/hashtag?hashtag={value}\">#{value}</a>"
+    )
 
 
 def _format_timestamp_tag(match: re.Match[str]) -> str:
@@ -462,6 +472,9 @@ _BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _UNDERLINE_RE = re.compile(r"__(.+?)__", re.DOTALL)
 _STRIKE_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
 _SPOILER_RE = re.compile(r"\|\|(.+?)\|\|", re.DOTALL)
+_NUMERIC_HASHTAG_RE = re.compile(
+    r"(?:(?<=^)|(?<=[^0-9A-Za-z_/:]))#([0-9]{1,64})(?![0-9A-Za-z_])"
+)
 
 _IMAGE_EXTENSIONS = (
     ".png",

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -255,3 +255,31 @@ def test_angle_bracket_links_are_unwrapped() -> None:
 
     assert "<https://example.com>" not in formatted.text
     assert "https://example.com" in formatted.text
+
+
+def test_numeric_hashtags_are_linked() -> None:
+    channel = sample_channel()
+    message = DiscordMessage(
+        id="6",
+        channel_id="123",
+        guild_id="999",
+        author_id="42",
+        author_name="Author",
+        content="Numbers #123456 and mix #token plus #987654.",
+        attachments=(),
+        embeds=(),
+        stickers=(),
+        role_ids=set(),
+    )
+
+    formatted = format_discord_message(message, channel)
+
+    assert (
+        '<a href="https://t.me/s/hashtag?hashtag=123456">#123456</a>'
+        in formatted.text
+    )
+    assert (
+        '<a href="https://t.me/s/hashtag?hashtag=987654">#987654</a>'
+        in formatted.text
+    )
+    assert "#token" in formatted.text

--- a/tests/test_send_formatted.py
+++ b/tests/test_send_formatted.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+
+from forward_monitor.models import FormattedTelegramMessage
+from forward_monitor.telegram import TelegramAPIProtocol, send_formatted
+
+
+class RecordingTelegramAPI(TelegramAPIProtocol):
+    def __init__(self) -> None:
+        self.messages: list[dict[str, object]] = []
+        self.photos: list[dict[str, object]] = []
+
+    async def get_updates(
+        self, offset: int | None = None, timeout: int = 30
+    ) -> list[dict[str, object]]:
+        raise NotImplementedError
+
+    async def set_my_commands(
+        self, commands: Iterable[tuple[str, str]]
+    ) -> None:
+        raise NotImplementedError
+
+    async def send_message(
+        self,
+        chat_id: int | str,
+        text: str,
+        *,
+        parse_mode: str | None = None,
+        disable_preview: bool = True,
+        message_thread_id: int | None = None,
+    ) -> None:
+        self.messages.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "parse_mode": parse_mode,
+                "disable_preview": disable_preview,
+                "thread_id": message_thread_id,
+            }
+        )
+
+    async def send_photo(
+        self,
+        chat_id: int | str,
+        photo: str,
+        *,
+        caption: str | None = None,
+        parse_mode: str | None = None,
+        message_thread_id: int | None = None,
+    ) -> None:
+        self.photos.append(
+            {
+                "chat_id": chat_id,
+                "photo": photo,
+                "caption": caption,
+                "parse_mode": parse_mode,
+                "thread_id": message_thread_id,
+            }
+        )
+
+    async def answer_callback_query(self, callback_id: str, text: str) -> None:
+        raise NotImplementedError
+
+
+def test_send_formatted_forwards_images() -> None:
+    api = RecordingTelegramAPI()
+    message = FormattedTelegramMessage(
+        text="Primary text",
+        extra_messages=("Extra",),
+        parse_mode="HTML",
+        disable_preview=True,
+        image_urls=(
+            "https://cdn.example.com/image-a.png",
+            "https://cdn.example.com/image-b.png",
+        ),
+    )
+
+    asyncio.run(send_formatted(api, "chat", message, thread_id=77))
+
+    assert len(api.messages) == 2
+    assert api.messages[0]["text"] == "Primary text"
+    assert api.messages[0]["parse_mode"] == "HTML"
+    assert api.messages[0]["disable_preview"] is True
+    assert api.messages[0]["thread_id"] == 77
+    assert api.messages[1]["text"] == "Extra"
+    assert api.messages[1]["thread_id"] == 77
+
+    assert [photo["photo"] for photo in api.photos] == [
+        "https://cdn.example.com/image-a.png",
+        "https://cdn.example.com/image-b.png",
+    ]
+    assert all(photo["caption"] is None for photo in api.photos)
+    assert all(photo["parse_mode"] is None for photo in api.photos)
+    assert all(photo["thread_id"] == 77 for photo in api.photos)


### PR DESCRIPTION
## Summary
- convert numeric-only hashtags into Telegram search links so they highlight correctly
- add regression tests for numeric hashtags and for forwarding image attachments

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e536159960832bbf4c2ef6ca7dd9c5