### PR TITLE
Stop converting numeric hashtags into links

### DIFF
--- a/src/forward_monitor/formatting.py
+++ b/src/forward_monitor/formatting.py
@@ -397,9 +397,7 @@ def _format_numeric_hashtag(match: re.Match[str]) -> str:
     value = match.group(1)
     if not value:
         return match.group(0)
-    return (
-        f"<a href=\"https://t.me/s/hashtag?hashtag={value}\">#{value}</a>"
-    )
+    return f"#{value}"
 
 
 def _format_timestamp_tag(match: re.Match[str]) -> str:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -257,7 +257,7 @@ def test_angle_bracket_links_are_unwrapped() -> None:
     assert "https://example.com" in formatted.text
 
 
-def test_numeric_hashtags_are_linked() -> None:
+def test_numeric_hashtags_are_plain_text() -> None:
     channel = sample_channel()
     message = DiscordMessage(
         id="6",
@@ -274,12 +274,8 @@ def test_numeric_hashtags_are_linked() -> None:
 
     formatted = format_discord_message(message, channel)
 
-    assert (
-        '<a href="https://t.me/s/hashtag?hashtag=123456">#123456</a>'
-        in formatted.text
-    )
-    assert (
-        '<a href="https://t.me/s/hashtag?hashtag=987654">#987654</a>'
-        in formatted.text
-    )
+    assert "#123456" in formatted.text
+    assert "#987654" in formatted.text
+    assert "https://t.me/s/hashtag?hashtag=123456" not in formatted.text
+    assert "https://t.me/s/hashtag?hashtag=987654" not in formatted.text
     assert "#token" in formatted.text


### PR DESCRIPTION
## Summary
- render numeric hashtags as plain text instead of Telegram hashtag links
- update formatting tests to cover the plain hashtag behaviour

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_b_68e53a81fa64832b87fb2e2d13eb268e