### PR TITLE
Revamp Telegram admin responses and grouping

### DIFF
--- a/tests/test_telegram_commands.py
+++ b/tests/test_telegram_commands.py
@@ -489,9 +489,11 @@ def test_send_recent_forwards_messages(tmp_path: Path) -> None:
         assert record is not None
         assert record.last_message_id == "102"
         assert api.messages
-        assert api.messages[0] == (
-            "Пересылка запущена (каналов: 1, лимит: 2). Это может занять несколько минут."
-        )
+        first_message = api.messages[0]
+        assert first_message.startswith("<b>📨 Ручная пересылка</b>")
+        assert "Каналов: 1" in first_message
+        assert "Лимит: 2" in first_message
+        assert "Пересылка запущена" in first_message
         assert any(message.startswith("PHOTO:") for message in api.messages)
         assert any("<b>Bold text</b>" in message for message in api.messages)
         assert any("Всего переслано: 2" in message for message in api.messages)
@@ -1249,12 +1251,16 @@ def test_set_healthcheck_updates_interval(tmp_path: Path) -> None:
         admin.args = "30"
         await controller._dispatch("set_healthcheck", admin)
         assert store.get_setting("runtime.health_interval") == "30.00"
-        assert api.messages[-1] == "Интервал health-check обновлён"
+        last_message = api.messages[-1]
+        assert last_message.startswith("<b>⏱️ Параметры</b>")
+        assert "Интервал health-check обновлён." in last_message
 
         admin.args = "5"
         await controller._dispatch("set_healthcheck", admin)
         assert store.get_setting("runtime.health_interval") == "30.00"
-        assert api.messages[-1] == "Минимальный интервал — 10 секунд"
+        error_message = api.messages[-1]
+        assert error_message.startswith("<b>⚠️ Параметры</b>")
+        assert "Минимальный интервал — 10 секунд." in error_message
 
     import asyncio
 

--- a/tests/test_telegram_controller.py
+++ b/tests/test_telegram_controller.py
@@ -456,7 +456,7 @@ def test_list_channels_grouped_output(tmp_path: Path) -> None:
         assert payload.count("💬 <b>Telegram") == 2
         assert "Alpha" in payload and "Beta" in payload and "Gamma" in payload
         assert payload.index("Alpha") < payload.index("Beta")
-        assert "Тема: <code>2</code>" in payload
+        assert "🧵 <b>Тема <code>2</code></b>" in payload
         assert "Нет доступа" in payload
 
     asyncio.run(runner())
@@ -499,6 +499,6 @@ def test_status_groups_channels_by_chat(tmp_path: Path) -> None:
         first_group = combined[first_idx:second_idx]
         assert "Alpha" in first_group and "Beta" in first_group
         assert "Gamma" in combined[second_idx:]
-        assert "Тема: <code>2</code>" in combined
+        assert "🧵 <b>Тема <code>2</code></b>" in combined
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- Add reusable helpers for emoji-rich panel responses and apply them across Telegram admin commands for consistent messaging and validation feedback. 【F:src/forward_monitor/telegram.py†L200-L776】【F:src/forward_monitor/telegram.py†L1668-L1799】
- Expand help documentation and channel management flows to highlight optional monitoring modes while modernising success/error notifications. 【F:src/forward_monitor/telegram.py†L820-L839】【F:src/forward_monitor/telegram.py†L1431-L1511】
- Rework status and channel listing output to group entries by chat/thread and update HTML chunk splitting for clean multi-message delivery. 【F:src/forward_monitor/telegram.py†L1150-L1360】【F:src/forward_monitor/telegram.py†L3002-L3083】

## Testing
- make ci


------
https://chatgpt.com/codex/tasks/task_b_68e54c892184832bb10c4d5d21da4a6e